### PR TITLE
Expose swarm events.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,12 +310,15 @@ enum IpfsEvent {
     Exit,
 }
 
+type TSwarmEvent<Types> = <TSwarm<Types> as Stream>::Item;
+
 /// Configured Ipfs which can only be started.
 pub struct UninitializedIpfs<Types: IpfsTypes> {
     repo: Arc<Repo<Types>>,
     keys: Keypair,
     options: IpfsOptions,
     repo_events: Receiver<RepoEvent>,
+    swarm_event_handler: Option<Arc<dyn Fn(&mut TSwarm<Types>, &TSwarmEvent<Types>) + Sync + Send>>,
 }
 
 impl<Types: IpfsTypes> UninitializedIpfs<Types> {
@@ -335,7 +338,36 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             keys,
             options,
             repo_events,
+            swarm_event_handler: None,
         }
+    }
+
+    /// Inject a handler for libp2p swarm events.
+    ///
+    /// You can provide a closure to handle libp2p events.
+    /// ```
+    /// # use ipfs::{IpfsOptions, UninitializedIpfs, TestTypes as Types};
+    /// # let opts = IpfsOptions::inmemory_with_generated_keys();
+    /// use ipfs::p2p::TSwarm;
+    /// use libp2p::swarm::SwarmEvent;
+    /// let uninit_ipfs: UninitializedIpfs<Types> = UninitializedIpfs::new(opts)
+    ///     .handle_swarm_events(|swarm:  &mut TSwarm<Types>, event: &SwarmEvent<_, _>| {
+    ///         if let SwarmEvent::ConnectionClosed {
+    ///             peer_id,
+    ///             endpoint,
+    ///             num_established,
+    ///             cause
+    ///         } = event {
+    ///             swarm.ban_peer_id(peer_id.clone())
+    ///         }
+    ///     });
+    /// ```
+    pub fn handle_swarm_events<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&mut TSwarm<Types>, &TSwarmEvent<Types>) + Sync + Send + 'static,
+    {
+        self.swarm_event_handler = Some(Arc::new(f));
+        self
     }
 
     /// Initialize the ipfs node. The returned `Ipfs` value is cloneable, send and sync, and the
@@ -352,6 +384,7 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             keys,
             repo_events,
             mut options,
+            swarm_event_handler,
         } = self;
 
         let root_span = options
@@ -400,6 +433,7 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             from_facade: receiver.fuse(),
             swarm,
             listening_addresses: HashMap::with_capacity(listening_addrs.len()),
+            swarm_event_handler,
         };
 
         for addr in listening_addrs.into_iter() {
@@ -1232,6 +1266,7 @@ struct IpfsFuture<Types: IpfsTypes> {
     repo_events: Fuse<Receiver<RepoEvent>>,
     from_facade: Fuse<Receiver<IpfsEvent>>,
     listening_addresses: HashMap<Multiaddr, (ListenerId, Option<Channel<Multiaddr>>)>,
+    swarm_event_handler: Option<Arc<dyn Fn(&mut TSwarm<Types>, &TSwarmEvent<Types>) + Sync + Send>>,
 }
 
 impl<TRepoTypes: RepoTypes> IpfsFuture<TRepoTypes> {
@@ -1381,6 +1416,9 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                 // exhaust the swarm before possibly causing the swarm to do more work by popping
                 // off the events from Ipfs and ... this looping goes on for a while.
                 done = false;
+                if let Some(handler) = self.swarm_event_handler.clone() {
+                    handler(&mut self.swarm, &inner)
+                }
                 match inner {
                     SwarmEvent::NewListenAddr { address, .. } => {
                         self.complete_listening_address_adding(address);


### PR DESCRIPTION
Add a swarm event handler to UninitializedIpfs and IpfsFuture to allow
users to perform actions based on the incoming SwarmEvents. An example
usecase could be to compare incoming connections to a list of allowed
addresses.
