### PR TITLE
Extend ipfs with custom libp2p behaviours

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ use futures::{
     stream::{Fuse, Stream},
 };
 use libp2p::swarm::NetworkBehaviour;
-use p2p::{ExtendedBehaviourBuilder, TExtendedSwarm};
+use p2p::{CustomBehaviourBuilder, TCustomSwarm};
 use tracing::Span;
 use tracing_futures::Instrument;
 
@@ -313,7 +313,7 @@ enum IpfsEvent {
 
 pub type UninitializedIpfs<Types> = UninitializedExtendedIpfs<Types, p2p::NoopBehaviour>;
 
-impl<Types: IpfsTypes> UninitializedIpfs<Types> {
+impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
     /// Configures a new UninitializedIpfs with from the given options and optionally a span.
     /// If the span is not given, it is defaulted to `tracing::trace_span!("ipfs")`.
     ///
@@ -344,54 +344,54 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             ipfs,
             receiver,
             repo_events,
-            behaviour: p2p::ExtendedBehaviour::new(swarm_options, arc_repo),
+            behaviour: p2p::Behaviour::new(swarm_options, arc_repo),
             options: options,
         }
     }
 }
 
-pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Behaviour: NetworkBehaviour> {
+pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     repo: Arc<Repo<Types>>,
     ipfs: Ipfs<Types>,
     receiver: Receiver<IpfsEvent>,
     repo_events: Receiver<RepoEvent>,
-    behaviour: p2p::ExtendedBehaviour<Types, Behaviour>,
+    behaviour: p2p::Behaviour<Types, Custom>,
     options: IpfsOptions,
 }
 
 impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
     UninitializedExtendedIpfs<Types, Behaviour>
 {
-    pub fn with_extended_behaviour<Ext: NetworkBehaviour>(
+    pub fn with_extended_behaviour<Custom: NetworkBehaviour<OutEvent = ()>>(
         self,
-        behaviour: Ext,
-    ) -> UninitializedExtendedIpfs<Types, Ext> {
+        behaviour: Custom,
+    ) -> UninitializedExtendedIpfs<Types, Custom> {
         UninitializedExtendedIpfs {
             repo: self.repo,
             ipfs: self.ipfs,
             receiver: self.receiver,
             repo_events: self.repo_events,
-            behaviour: self.behaviour.new_extended_behaviour(behaviour),
             options: self.options,
+            behaviour: self.behaviour.new_custom_behaviour(behaviour),
         }
     }
 
-    pub fn with_extended_behaviour_from_builder<Ext, ExtBuilder>(
+    pub fn with_extended_behaviour_from_builder<Custom, CustomBuilder>(
         self,
-        behaviour_builder: ExtBuilder,
-    ) -> UninitializedExtendedIpfs<Types, Ext>
+        behaviour_builder: CustomBuilder,
+    ) -> UninitializedExtendedIpfs<Types, Custom>
     where
-        Ext: NetworkBehaviour<OutEvent = ()>,
-        ExtBuilder: ExtendedBehaviourBuilder<Types, Ext>,
+        Custom: NetworkBehaviour<OutEvent = ()>,
+        CustomBuilder: CustomBehaviourBuilder<Types, Custom>,
     {
-        let behaviour = behaviour_builder.build(self.ipfs.clone());
+        let custom = behaviour_builder.build(self.ipfs.clone());
         UninitializedExtendedIpfs {
             repo: self.repo,
             ipfs: self.ipfs,
             receiver: self.receiver,
             repo_events: self.repo_events,
-            behaviour: self.behaviour.new_extended_behaviour(behaviour),
             options: self.options,
+            behaviour: self.behaviour.new_custom_behaviour(custom),
         }
     }
     /// Initialize the ipfs node. The returned `Ipfs` value is cloneable, send and sync, and the
@@ -440,7 +440,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
             listening_addrs, ..
         } = options;
 
-        let mut fut = IpfsFuture {
+        let mut fut: IpfsFuture<Types, Behaviour> = IpfsFuture {
             repo_events: repo_events.fuse(),
             from_facade: receiver.fuse(),
             swarm,
@@ -1273,7 +1273,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
 /// Background task of `Ipfs` created when calling `UninitializedIpfs::start`.
 // The receivers are Fuse'd so that we don't have to manage state on them being exhausted.
 struct IpfsFuture<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> {
-    swarm: TExtendedSwarm<Types, Behaviour>,
+    swarm: TCustomSwarm<Types, Behaviour>,
     repo_events: Fuse<Receiver<RepoEvent>>,
     from_facade: Fuse<Receiver<IpfsEvent>>,
     listening_addresses: HashMap<Multiaddr, (ListenerId, Option<Channel<Multiaddr>>)>,
@@ -1451,11 +1451,11 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
 
                 match inner {
                     IpfsEvent::Connect(target, ret) => {
-                        ret.send(self.swarm.behaviour_mut().inner.connect(target))
+                        ret.send(self.swarm.behaviour_mut().connect(target))
                             .ok();
                     }
                     IpfsEvent::Addresses(ret) => {
-                        let addrs = self.swarm.behaviour_mut().inner.addrs();
+                        let addrs = self.swarm.behaviour_mut().addrs();
                         ret.send(Ok(addrs)).ok();
                     }
                     IpfsEvent::Listeners(ret) => {
@@ -1463,12 +1463,12 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         ret.send(Ok(listeners)).ok();
                     }
                     IpfsEvent::Connections(ret) => {
-                        let connections = self.swarm.behaviour_mut().inner.connections();
+                        let connections = self.swarm.behaviour_mut().connections();
                         ret.send(Ok(connections.collect())).ok();
                     }
                     IpfsEvent::Disconnect(addr, ret) => {
                         if let Some(disconnector) =
-                            self.swarm.behaviour_mut().inner.disconnect(addr)
+                            self.swarm.behaviour_mut().disconnect(addr)
                         {
                             disconnector.disconnect(&mut self.swarm);
                         }
@@ -1485,16 +1485,16 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                     }
                     IpfsEvent::PubsubSubscribe(topic, ret) => {
                         let _ =
-                            ret.send(self.swarm.behaviour_mut().inner.pubsub().subscribe(topic));
+                            ret.send(self.swarm.behaviour_mut().pubsub().subscribe(topic));
                     }
                     IpfsEvent::PubsubUnsubscribe(topic, ret) => {
                         let _ =
-                            ret.send(self.swarm.behaviour_mut().inner.pubsub().unsubscribe(topic));
+                            ret.send(self.swarm.behaviour_mut().pubsub().unsubscribe(topic));
                     }
                     IpfsEvent::PubsubPublish(topic, data, ret) => {
                         self.swarm
                             .behaviour_mut()
-                            .inner
+                            
                             .pubsub()
                             .publish(topic, data);
                         let _ = ret.send(());
@@ -1504,19 +1504,19 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let _ = ret.send(
                             self.swarm
                                 .behaviour_mut()
-                                .inner
+                                
                                 .pubsub()
                                 .subscribed_peers(&topic),
                         );
                     }
                     IpfsEvent::PubsubPeers(None, ret) => {
-                        let _ = ret.send(self.swarm.behaviour_mut().inner.pubsub().known_peers());
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().known_peers());
                     }
                     IpfsEvent::PubsubSubscribed(ret) => {
                         let _ = ret.send(
                             self.swarm
                                 .behaviour_mut()
-                                .inner
+                                
                                 .pubsub()
                                 .subscribed_topics(),
                         );
@@ -1525,19 +1525,19 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let list = if let Some(peer) = peer {
                             self.swarm
                                 .behaviour_mut()
-                                .inner
+                                
                                 .bitswap()
                                 .peer_wantlist(&peer)
                                 .unwrap_or_default()
                         } else {
-                            self.swarm.behaviour_mut().inner.bitswap().local_wantlist()
+                            self.swarm.behaviour_mut().bitswap().local_wantlist()
                         };
                         let _ = ret.send(list);
                     }
                     IpfsEvent::BitswapStats(ret) => {
-                        let stats = self.swarm.behaviour_mut().inner.bitswap().stats();
-                        let peers = self.swarm.behaviour_mut().inner.bitswap().peers();
-                        let wantlist = self.swarm.behaviour_mut().inner.bitswap().local_wantlist();
+                        let stats = self.swarm.behaviour_mut().bitswap().stats();
+                        let peers = self.swarm.behaviour_mut().bitswap().peers();
+                        let wantlist = self.swarm.behaviour_mut().bitswap().local_wantlist();
                         let _ = ret.send((stats, peers, wantlist).into());
                     }
                     IpfsEvent::AddListeningAddress(addr, ret) => {
@@ -1559,21 +1559,21 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let _ = ret.send(removed);
                     }
                     IpfsEvent::Bootstrap(ret) => {
-                        let future = self.swarm.behaviour_mut().inner.bootstrap();
+                        let future = self.swarm.behaviour_mut().bootstrap();
                         let _ = ret.send(future);
                     }
                     IpfsEvent::AddPeer(peer_id, addr) => {
-                        self.swarm.behaviour_mut().inner.add_peer(peer_id, addr);
+                        self.swarm.behaviour_mut().add_peer(peer_id, addr);
                     }
                     IpfsEvent::GetClosestPeers(peer_id, ret) => {
-                        let future = self.swarm.behaviour_mut().inner.get_closest_peers(peer_id);
+                        let future = self.swarm.behaviour_mut().get_closest_peers(peer_id);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::GetBitswapPeers(ret) => {
                         let peers = self
                             .swarm
                             .behaviour_mut()
-                            .inner
+                            
                             .bitswap()
                             .connected_peers
                             .keys()
@@ -1585,7 +1585,7 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let swarm_addrs = self
                             .swarm
                             .behaviour_mut()
-                            .inner
+                            
                             .swarm
                             .connections_to(&peer_id);
                         let locally_known_addrs = if !swarm_addrs.is_empty() {
@@ -1593,7 +1593,7 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         } else {
                             self.swarm
                                 .behaviour_mut()
-                                .inner
+                                
                                 .kademlia()
                                 .addresses_of_peer(&peer_id)
                         };
@@ -1601,44 +1601,44 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                             Either::Left(locally_known_addrs)
                         } else {
                             Either::Right(
-                                self.swarm.behaviour_mut().inner.get_closest_peers(peer_id),
+                                self.swarm.behaviour_mut().get_closest_peers(peer_id),
                             )
                         };
                         let _ = ret.send(addrs);
                     }
                     IpfsEvent::GetProviders(cid, ret) => {
-                        let future = self.swarm.behaviour_mut().inner.get_providers(cid);
+                        let future = self.swarm.behaviour_mut().get_providers(cid);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::Provide(cid, ret) => {
-                        let _ = ret.send(self.swarm.behaviour_mut().inner.start_providing(cid));
+                        let _ = ret.send(self.swarm.behaviour_mut().start_providing(cid));
                     }
                     IpfsEvent::DhtGet(key, quorum, ret) => {
-                        let future = self.swarm.behaviour_mut().inner.dht_get(key, quorum);
+                        let future = self.swarm.behaviour_mut().dht_get(key, quorum);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::DhtPut(key, value, quorum, ret) => {
-                        let future = self.swarm.behaviour_mut().inner.dht_put(key, value, quorum);
+                        let future = self.swarm.behaviour_mut().dht_put(key, value, quorum);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::GetBootstrappers(ret) => {
-                        let list = self.swarm.behaviour_mut().inner.get_bootstrappers();
+                        let list = self.swarm.behaviour_mut().get_bootstrappers();
                         let _ = ret.send(list);
                     }
                     IpfsEvent::AddBootstrapper(addr, ret) => {
-                        let result = self.swarm.behaviour_mut().inner.add_bootstrapper(addr);
+                        let result = self.swarm.behaviour_mut().add_bootstrapper(addr);
                         let _ = ret.send(result);
                     }
                     IpfsEvent::RemoveBootstrapper(addr, ret) => {
-                        let result = self.swarm.behaviour_mut().inner.remove_bootstrapper(addr);
+                        let result = self.swarm.behaviour_mut().remove_bootstrapper(addr);
                         let _ = ret.send(result);
                     }
                     IpfsEvent::ClearBootstrappers(ret) => {
-                        let list = self.swarm.behaviour_mut().inner.clear_bootstrappers();
+                        let list = self.swarm.behaviour_mut().clear_bootstrappers();
                         let _ = ret.send(list);
                     }
                     IpfsEvent::RestoreBootstrappers(ret) => {
-                        let list = self.swarm.behaviour_mut().inner.restore_bootstrappers();
+                        let list = self.swarm.behaviour_mut().restore_bootstrappers();
                         let _ = ret.send(list);
                     }
                     IpfsEvent::Exit => {
@@ -1652,11 +1652,11 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
             // wants this to be written with a `while let`.
             while let Poll::Ready(Some(evt)) = Pin::new(&mut self.repo_events).poll_next(ctx) {
                 match evt {
-                    RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().inner.want_block(cid),
+                    RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().want_block(cid),
                     RepoEvent::UnwantBlock(cid) => self
                         .swarm
                         .behaviour_mut()
-                        .inner
+                        
                         .bitswap()
                         .cancel_block(&cid),
                     RepoEvent::NewBlock(cid, ret) => {
@@ -1664,19 +1664,19 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         // associated Block ourselves
                         self.swarm
                             .behaviour_mut()
-                            .inner
+                            
                             .bitswap()
                             .cancel_block(&cid);
                         // currently disabled; see https://github.com/rs-ipfs/rust-ipfs/pull/281#discussion_r465583345
                         // for details regarding the concerns about enabling this functionality as-is
                         if false {
-                            let _ = ret.send(self.swarm.behaviour_mut().inner.start_providing(cid));
+                            let _ = ret.send(self.swarm.behaviour_mut().start_providing(cid));
                         } else {
                             let _ = ret.send(Err(anyhow!("not actively providing blocks yet")));
                         }
                     }
                     RepoEvent::RemovedBlock(cid) => {
-                        self.swarm.behaviour_mut().inner.stop_providing_block(&cid)
+                        self.swarm.behaviour_mut().stop_providing_block(&cid)
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,15 @@ enum IpfsEvent {
     Exit,
 }
 
+pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
+    behaviour: p2p::Behaviour<Types, Custom>,
+    ipfs_event_channel: (Sender<IpfsEvent>, Receiver<IpfsEvent>),
+    keys: Keypair,
+    options: IpfsOptions,
+    repo: Arc<Repo<Types>>,
+    repo_events: Receiver<RepoEvent>,
+}
+
 pub type UninitializedIpfs<Types> = UninitializedExtendedIpfs<Types, p2p::NoopBehaviour>;
 
 impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
@@ -327,36 +336,17 @@ impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
         let arc_repo = Arc::new(repo);
         let swarm_options = SwarmOptions::from(&options);
 
-        let (to_task, receiver) = channel::<IpfsEvent>(1);
-
-        // stored in the Ipfs, instrumenting every method call
-        let facade_span = tracing::trace_span!("facade");
-
-        let ipfs = Ipfs {
-            span: facade_span,
-            repo: arc_repo.clone(),
-            keys: DebuggableKeypair(keys),
-            to_task,
-        };
+        let channel = channel::<IpfsEvent>(1);
 
         Self {
-            repo: arc_repo.clone(),
-            ipfs,
-            receiver,
-            repo_events,
             behaviour: p2p::Behaviour::new(swarm_options, arc_repo),
+            ipfs_event_channel: channel,
+            keys,
             options: options,
+            repo: arc_repo.clone(),
+            repo_events,
         }
     }
-}
-
-pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
-    repo: Arc<Repo<Types>>,
-    ipfs: Ipfs<Types>,
-    receiver: Receiver<IpfsEvent>,
-    repo_events: Receiver<RepoEvent>,
-    behaviour: p2p::Behaviour<Types, Custom>,
-    options: IpfsOptions,
 }
 
 impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
@@ -367,12 +357,12 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         behaviour: Custom,
     ) -> UninitializedExtendedIpfs<Types, Custom> {
         UninitializedExtendedIpfs {
-            repo: self.repo,
-            ipfs: self.ipfs,
-            receiver: self.receiver,
-            repo_events: self.repo_events,
-            options: self.options,
             behaviour: self.behaviour.new_custom_behaviour(behaviour),
+            ipfs_event_channel: self.ipfs_event_channel,
+            keys: self.keys,
+            options: self.options,
+            repo: self.repo,
+            repo_events: self.repo_events,
         }
     }
 
@@ -384,14 +374,14 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         Custom: NetworkBehaviour<OutEvent = ()>,
         CustomBuilder: CustomBehaviourBuilder<Types, Custom>,
     {
-        let custom = behaviour_builder.build(self.ipfs.clone());
+        let custom = behaviour_builder.build(self.ipfs_event_channel.0.clone());
         UninitializedExtendedIpfs {
-            repo: self.repo,
-            ipfs: self.ipfs,
-            receiver: self.receiver,
-            repo_events: self.repo_events,
-            options: self.options,
             behaviour: self.behaviour.new_custom_behaviour(custom),
+            ipfs_event_channel: self.ipfs_event_channel,
+            keys: self.keys,
+            options: self.options,
+            repo: self.repo,
+            repo_events: self.repo_events,
         }
     }
     /// Initialize the ipfs node. The returned `Ipfs` value is cloneable, send and sync, and the
@@ -404,12 +394,12 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         use futures::stream::StreamExt;
 
         let Self {
+            behaviour,
+            ipfs_event_channel,
+            keys,
+            mut options,
             repo,
             repo_events,
-            mut options,
-            ipfs,
-            receiver,
-            behaviour,
         } = self;
 
         let root_span = options
@@ -428,7 +418,17 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         // instruments the IpfsFuture, the background task.
         let swarm_span = tracing::trace_span!(parent: &root_span, "swarm");
 
+        // stored in the Ipfs, instrumenting every method call
+        let facade_span = tracing::trace_span!("facade");
+
         repo.init().instrument(init_span.clone()).await?;
+
+        let ipfs = Ipfs {
+            span: facade_span,
+            repo,
+            keys: DebuggableKeypair(keys),
+            to_task: ipfs_event_channel.0,
+        };
 
         // FIXME: mutating options above is an unfortunate side-effect of this call, which could be
         // reordered for less error prone code.
@@ -442,7 +442,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
 
         let mut fut: IpfsFuture<Types, Behaviour> = IpfsFuture {
             repo_events: repo_events.fuse(),
-            from_facade: receiver.fuse(),
+            from_facade: ipfs_event_channel.1.fuse(),
             swarm,
             listening_addresses: HashMap::with_capacity(listening_addrs.len()),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,10 @@ impl IpfsOptions {
             span: None,
         }
     }
+
+    pub fn create_uninitialised_ipfs<Types: IpfsTypes>(self) -> UninitializedIpfs<Types> {
+        UninitializedIpfs::new(self)
+    }
 }
 
 /// Workaround for libp2p::identity::Keypair missing a Debug impl, works with references and owned
@@ -253,7 +257,7 @@ type Channel<T> = OneshotSender<Result<T, Error>>;
 /// Events used internally to communicate with the swarm, which is executed in the the background
 /// task.
 #[derive(Debug)]
-enum IpfsEvent {
+pub enum IpfsEvent {
     /// Connect
     Connect(
         MultiaddrWithPeerId,
@@ -311,6 +315,9 @@ enum IpfsEvent {
     Exit,
 }
 
+/// The general representation of the builder for Ipfs<Types>.
+/// 
+/// For the default representation without any custom NetworkBehaviours, see [UninitializedIpfs](`crate::UninitializedIpfs`).
 pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     behaviour: p2p::Behaviour<Types, Custom>,
     ipfs_event_channel: (Sender<IpfsEvent>, Receiver<IpfsEvent>),
@@ -320,6 +327,7 @@ pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<
     repo_events: Receiver<RepoEvent>,
 }
 
+/// The default builder for Ipfs<Types> without any custom NetworkBehaviours.
 pub type UninitializedIpfs<Types> = UninitializedExtendedIpfs<Types, p2p::NoopBehaviour>;
 
 impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
@@ -339,11 +347,11 @@ impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
         let channel = channel::<IpfsEvent>(1);
 
         Self {
-            behaviour: p2p::Behaviour::new(swarm_options, arc_repo),
+            behaviour: p2p::Behaviour::new(swarm_options, arc_repo.clone()),
             ipfs_event_channel: channel,
             keys,
             options: options,
-            repo: arc_repo.clone(),
+            repo: arc_repo,
             repo_events,
         }
     }
@@ -352,6 +360,10 @@ impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
 impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
     UninitializedExtendedIpfs<Types, Behaviour>
 {
+    /// Set a custom [NetworkBehaviour](`libp2p::swarm::NetworkBehaviour`) for the Ipfs swarm.
+    /// 
+    /// Custom behaviours must have an [OutEvent](`libp2p::swarm::NetworkBehaviour::OutEvent`)
+    /// of `()`.
     pub fn with_extended_behaviour<Custom: NetworkBehaviour<OutEvent = ()>>(
         self,
         behaviour: Custom,
@@ -366,6 +378,11 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         }
     }
 
+    /// Set a custom [NetworkBehaviour](`libp2p::swarm::NetworkBehaviour`) for the Ipfs swarm from
+    /// a [CustomBehaviourBuilder](`crate::p2p::CustomBehaviourBuilder`).
+    /// 
+    /// Custom behaviours must have an [OutEvent](`libp2p::swarm::NetworkBehaviour::OutEvent`)
+    /// of `()`.
     pub fn with_extended_behaviour_from_builder<Custom, CustomBuilder>(
         self,
         behaviour_builder: CustomBuilder,
@@ -384,11 +401,12 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
             repo_events: self.repo_events,
         }
     }
+
     /// Initialize the ipfs node. The returned `Ipfs` value is cloneable, send and sync, and the
     /// future should be spawned on an executor as soon as possible.
     ///
     /// The future returned from this method should not need
-    /// (instrumenting)[`tracing_futures::Instrument::instrument`] as the [`IpfsOptions::span`]
+    /// [instrumenting](`tracing_futures::Instrument::instrument`) as the [`IpfsOptions::span`]
     /// will be used as parent span for all of the awaited and created futures.
     pub async fn start(self) -> Result<(Ipfs<Types>, impl Future<Output = ()>), Error> {
         use futures::stream::StreamExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ use futures::{
     stream::{Fuse, Stream},
 };
 use libp2p::swarm::NetworkBehaviour;
-use p2p::{CustomBehaviourBuilder, TCustomSwarm};
 use tracing::Span;
 use tracing_futures::Instrument;
 
@@ -71,7 +70,7 @@ use self::{
     ipns::Ipns,
     p2p::{
         addr::{could_be_bound_from_ephemeral, starts_unspecified},
-        create_swarm, SwarmOptions,
+        create_swarm, CustomBehaviourBuilder, SwarmOptions, TCustomSwarm,
     },
     repo::{create_repo, Repo, RepoEvent, RepoOptions},
     subscription::SubscriptionFuture,
@@ -316,7 +315,7 @@ pub enum IpfsEvent {
 }
 
 /// The general representation of the builder for Ipfs<Types>.
-/// 
+///
 /// For the default representation without any custom NetworkBehaviours, see [UninitializedIpfs](`crate::UninitializedIpfs`).
 pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     behaviour: p2p::Behaviour<Types, Custom>,
@@ -361,7 +360,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
     UninitializedExtendedIpfs<Types, Behaviour>
 {
     /// Set a custom [NetworkBehaviour](`libp2p::swarm::NetworkBehaviour`) for the Ipfs swarm.
-    /// 
+    ///
     /// Custom behaviours must have an [OutEvent](`libp2p::swarm::NetworkBehaviour::OutEvent`)
     /// of `()`.
     pub fn with_extended_behaviour<Custom: NetworkBehaviour<OutEvent = ()>>(
@@ -380,7 +379,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
 
     /// Set a custom [NetworkBehaviour](`libp2p::swarm::NetworkBehaviour`) for the Ipfs swarm from
     /// a [CustomBehaviourBuilder](`crate::p2p::CustomBehaviourBuilder`).
-    /// 
+    ///
     /// Custom behaviours must have an [OutEvent](`libp2p::swarm::NetworkBehaviour::OutEvent`)
     /// of `()`.
     pub fn with_extended_behaviour_from_builder<Custom, CustomBuilder>(
@@ -429,15 +428,15 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         // the "current" span which is not entered but the awaited futures are instrumented with it
         let init_span = tracing::trace_span!(parent: &root_span, "init");
 
+        // stored in the Ipfs, instrumenting every method call
+        let facade_span = tracing::trace_span!("facade");
+
         // stored in the executor given to libp2p, used to spawn at least the connections,
         // instrumenting each of those.
         let exec_span = tracing::trace_span!(parent: &root_span, "exec");
 
         // instruments the IpfsFuture, the background task.
         let swarm_span = tracing::trace_span!(parent: &root_span, "swarm");
-
-        // stored in the Ipfs, instrumenting every method call
-        let facade_span = tracing::trace_span!("facade");
 
         repo.init().instrument(init_span.clone()).await?;
 
@@ -451,8 +450,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         // FIXME: mutating options above is an unfortunate side-effect of this call, which could be
         // reordered for less error prone code.
         let swarm_options = SwarmOptions::from(&options);
-        let swarm =
-            init_span.in_scope(|| create_swarm(swarm_options, exec_span, behaviour))?;
+        let swarm = init_span.in_scope(|| create_swarm(swarm_options, exec_span, behaviour))?;
 
         let IpfsOptions {
             listening_addrs, ..
@@ -1469,8 +1467,7 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
 
                 match inner {
                     IpfsEvent::Connect(target, ret) => {
-                        ret.send(self.swarm.behaviour_mut().connect(target))
-                            .ok();
+                        ret.send(self.swarm.behaviour_mut().connect(target)).ok();
                     }
                     IpfsEvent::Addresses(ret) => {
                         let addrs = self.swarm.behaviour_mut().addrs();
@@ -1485,9 +1482,7 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         ret.send(Ok(connections.collect())).ok();
                     }
                     IpfsEvent::Disconnect(addr, ret) => {
-                        if let Some(disconnector) =
-                            self.swarm.behaviour_mut().disconnect(addr)
-                        {
+                        if let Some(disconnector) = self.swarm.behaviour_mut().disconnect(addr) {
                             disconnector.disconnect(&mut self.swarm);
                         }
                         ret.send(Ok(())).ok();
@@ -1502,48 +1497,30 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let _ = ret.send(addresses);
                     }
                     IpfsEvent::PubsubSubscribe(topic, ret) => {
-                        let _ =
-                            ret.send(self.swarm.behaviour_mut().pubsub().subscribe(topic));
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().subscribe(topic));
                     }
                     IpfsEvent::PubsubUnsubscribe(topic, ret) => {
-                        let _ =
-                            ret.send(self.swarm.behaviour_mut().pubsub().unsubscribe(topic));
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().unsubscribe(topic));
                     }
                     IpfsEvent::PubsubPublish(topic, data, ret) => {
-                        self.swarm
-                            .behaviour_mut()
-                            
-                            .pubsub()
-                            .publish(topic, data);
+                        self.swarm.behaviour_mut().pubsub().publish(topic, data);
                         let _ = ret.send(());
                     }
                     IpfsEvent::PubsubPeers(Some(topic), ret) => {
                         let topic = libp2p::floodsub::Topic::new(topic);
-                        let _ = ret.send(
-                            self.swarm
-                                .behaviour_mut()
-                                
-                                .pubsub()
-                                .subscribed_peers(&topic),
-                        );
+                        let _ =
+                            ret.send(self.swarm.behaviour_mut().pubsub().subscribed_peers(&topic));
                     }
                     IpfsEvent::PubsubPeers(None, ret) => {
                         let _ = ret.send(self.swarm.behaviour_mut().pubsub().known_peers());
                     }
                     IpfsEvent::PubsubSubscribed(ret) => {
-                        let _ = ret.send(
-                            self.swarm
-                                .behaviour_mut()
-                                
-                                .pubsub()
-                                .subscribed_topics(),
-                        );
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().subscribed_topics());
                     }
                     IpfsEvent::WantList(peer, ret) => {
                         let list = if let Some(peer) = peer {
                             self.swarm
                                 .behaviour_mut()
-                                
                                 .bitswap()
                                 .peer_wantlist(&peer)
                                 .unwrap_or_default()
@@ -1591,7 +1568,6 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let peers = self
                             .swarm
                             .behaviour_mut()
-                            
                             .bitswap()
                             .connected_peers
                             .keys()
@@ -1600,27 +1576,19 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let _ = ret.send(peers);
                     }
                     IpfsEvent::FindPeer(peer_id, local_only, ret) => {
-                        let swarm_addrs = self
-                            .swarm
-                            .behaviour_mut()
-                            
-                            .swarm
-                            .connections_to(&peer_id);
+                        let swarm_addrs = self.swarm.behaviour_mut().swarm.connections_to(&peer_id);
                         let locally_known_addrs = if !swarm_addrs.is_empty() {
                             swarm_addrs
                         } else {
                             self.swarm
                                 .behaviour_mut()
-                                
                                 .kademlia()
                                 .addresses_of_peer(&peer_id)
                         };
                         let addrs = if !locally_known_addrs.is_empty() || local_only {
                             Either::Left(locally_known_addrs)
                         } else {
-                            Either::Right(
-                                self.swarm.behaviour_mut().get_closest_peers(peer_id),
-                            )
+                            Either::Right(self.swarm.behaviour_mut().get_closest_peers(peer_id))
                         };
                         let _ = ret.send(addrs);
                     }
@@ -1671,20 +1639,13 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
             while let Poll::Ready(Some(evt)) = Pin::new(&mut self.repo_events).poll_next(ctx) {
                 match evt {
                     RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().want_block(cid),
-                    RepoEvent::UnwantBlock(cid) => self
-                        .swarm
-                        .behaviour_mut()
-                        
-                        .bitswap()
-                        .cancel_block(&cid),
+                    RepoEvent::UnwantBlock(cid) => {
+                        self.swarm.behaviour_mut().bitswap().cancel_block(&cid)
+                    }
                     RepoEvent::NewBlock(cid, ret) => {
                         // TODO: consider if cancel is applicable in cases where we provide the
                         // associated Block ourselves
-                        self.swarm
-                            .behaviour_mut()
-                            
-                            .bitswap()
-                            .cancel_block(&cid);
+                        self.swarm.behaviour_mut().bitswap().cancel_block(&cid);
                         // currently disabled; see https://github.com/rs-ipfs/rust-ipfs/pull/281#discussion_r465583345
                         // for details regarding the concerns about enabling this functionality as-is
                         if false {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -22,6 +22,10 @@ use multibase::Base;
 use std::{convert::TryInto, sync::Arc};
 use tokio::task;
 
+/// A "do-nothing" behaviour.
+/// 
+/// This is the default "custom" behaviour for Ipfs. This is replaced by supplying a custom
+/// behaviour to the [UninitializedIpfs](`crate::UninitializedIpfs`).
 #[derive(Clone, Default, NetworkBehaviour)]
 pub struct NoopBehaviour {
     inner: DummyBehaviour
@@ -31,6 +35,7 @@ impl NetworkBehaviourEventProcess<void::Void> for NoopBehaviour {
     fn inject_event(&mut self, _event: void::Void) {}
 }
 
+/// Enables the building of custom NetworkBehaviours which need access to the Ipfs interface.
 pub trait CustomBehaviourBuilder<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     /// Build method for your NetworkBehaviour implementation if your behaviour needs access to IPFS at runtime.
     /// 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -21,28 +21,6 @@ use multibase::Base;
 use std::{convert::TryInto, sync::Arc};
 use tokio::task;
 
-#[derive(libp2p::NetworkBehaviour)]
-pub struct ExtendedBehaviour<Types: IpfsTypes, Ext: NetworkBehaviour> {
-    pub(crate) inner: Behaviour<Types>,
-    custom: Ext,
-}
-
-impl<Types: IpfsTypes, Ext: NetworkBehaviour> NetworkBehaviourEventProcess<()> for ExtendedBehaviour<Types, Ext> {
-    fn inject_event(&mut self, _event: ()) {}
-}
-impl<Types: IpfsTypes, Ext: NetworkBehaviour> NetworkBehaviourEventProcess<void::Void> for ExtendedBehaviour<Types, Ext> {
-    fn inject_event(&mut self, _event: void::Void) {}
-}
-
-impl<Types: IpfsTypes, Ext: NetworkBehaviour> ExtendedBehaviour<Types, Ext> {
-    pub(crate) fn new_extended_behaviour<NExt: NetworkBehaviour>(self, new: NExt) -> ExtendedBehaviour<Types, NExt> {
-        ExtendedBehaviour {
-            inner: self.inner,
-            custom: new,
-        }
-    }
-}
-
 #[derive(Clone, Default, NetworkBehaviour)]
 pub struct NoopBehaviour {
     inner: DummyBehaviour
@@ -52,25 +30,16 @@ impl NetworkBehaviourEventProcess<void::Void> for NoopBehaviour {
     fn inject_event(&mut self, _event: void::Void) {}
 }
 
-pub trait ExtendedBehaviourBuilder<Types: IpfsTypes, Ext: NetworkBehaviour> {
+pub trait CustomBehaviourBuilder<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     /// Build method for your NetworkBehaviour implementation if your behaviour needs access to IPFS at runtime.
     /// 
     /// The IPFS object will be uninitialised until started with ExtendedUninitialisedIpfs::start
-    fn build(self, ipfs: Ipfs<Types>) -> Ext;
-}
-
-impl<Types: IpfsTypes> ExtendedBehaviour<Types, NoopBehaviour> {
-    pub fn new(options: SwarmOptions, repo: Arc<Repo<Types>>) -> Self {
-        Self {
-            inner: Behaviour::new(options, repo),
-            custom: NoopBehaviour::default(),
-        }
-    }
+    fn build(self, ipfs: Ipfs<Types>) -> Custom;
 }
 
 /// Behaviour type.
 #[derive(libp2p::NetworkBehaviour)]
-pub struct Behaviour<Types: IpfsTypes> {
+pub struct Behaviour<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     #[behaviour(ignore)]
     repo: Arc<Repo<Types>>,
     // mdns: Toggle<TokioMdns>,
@@ -82,6 +51,7 @@ pub struct Behaviour<Types: IpfsTypes> {
     identify: Identify,
     pubsub: Pubsub,
     pub swarm: SwarmApi,
+    custom: Custom,
 }
 
 /// Represents the result of a Kademlia query.
@@ -95,10 +65,10 @@ pub enum KadResult {
     Records(Vec<Record>),
 }
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<()> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<()> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, _event: ()) {}
 }
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<void::Void> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<void::Void> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, _event: void::Void) {}
 }
 
@@ -123,7 +93,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<MdnsEvent> for Behaviour<Typ
 }
 */
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, event: KademliaEvent) {
         use libp2p::kad::{
             AddProviderError, AddProviderOk, BootstrapError, BootstrapOk, GetClosestPeersError,
@@ -367,7 +337,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
     }
 }
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, event: BitswapEvent) {
         match event {
             BitswapEvent::ReceivedBlock(peer_id, block) => {
@@ -423,7 +393,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<
     }
 }
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<PingEvent> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<PingEvent> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, event: PingEvent) {
         use libp2p::ping::handler::{PingFailure, PingSuccess};
         match event {
@@ -461,13 +431,13 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<PingEvent> for Behaviour<Typ
     }
 }
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, event: IdentifyEvent) {
         trace!("identify: {:?}", event);
     }
 }
 
-impl<Types: IpfsTypes> Behaviour<Types> {
+impl<Types: IpfsTypes> Behaviour<Types, NoopBehaviour> {
     /// Create a Kademlia behaviour with the IPFS bootstrap nodes.
     pub fn new(options: SwarmOptions, repo: Arc<Repo<Types>>) -> Self {
         info!("net: starting with peer id {}", options.peer_id);
@@ -520,6 +490,23 @@ impl<Types: IpfsTypes> Behaviour<Types> {
             identify,
             pubsub,
             swarm,
+            custom:  NoopBehaviour::default(),
+        }
+    }
+}
+
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> Behaviour<Types, Custom> {
+    pub(crate) fn new_custom_behaviour<New: NetworkBehaviour<OutEvent = ()>>(self, new: New) -> Behaviour<Types, New> {
+        Behaviour {
+            repo: self.repo,
+            kademlia: self.kademlia,
+            kad_subscriptions: self.kad_subscriptions,
+            bitswap: self.bitswap,
+            ping: self.ping,
+            identify: self.identify,
+            pubsub: self.pubsub,
+            swarm: self.swarm,
+            custom: new,
         }
     }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -4,9 +4,10 @@ use crate::config::BOOTSTRAP_NODES;
 use crate::p2p::{MultiaddrWithPeerId, SwarmOptions};
 use crate::repo::{BlockPut, Repo};
 use crate::subscription::{SubscriptionFuture, SubscriptionRegistry};
-use crate::{IpfsTypes, Ipfs};
+use crate::{IpfsTypes, IpfsEvent};
 use anyhow::anyhow;
 use cid::Cid;
+use futures::channel::mpsc::Sender;
 use ipfs_bitswap::{Bitswap, BitswapEvent};
 use libp2p::NetworkBehaviour;
 use libp2p::core::{Multiaddr, PeerId};
@@ -33,8 +34,8 @@ impl NetworkBehaviourEventProcess<void::Void> for NoopBehaviour {
 pub trait CustomBehaviourBuilder<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     /// Build method for your NetworkBehaviour implementation if your behaviour needs access to IPFS at runtime.
     /// 
-    /// The IPFS object will be uninitialised until started with ExtendedUninitialisedIpfs::start
-    fn build(self, ipfs: Ipfs<Types>) -> Custom;
+    /// Building a NetworkBehaviour implementation with this function will give it access to push events onto the IPFS event channel.
+    fn build(self, ipfs_event_sink: Sender<IpfsEvent>) -> Custom;
 }
 
 /// Behaviour type.

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -16,13 +16,13 @@ mod transport;
 pub use addr::{MultiaddrWithPeerId, MultiaddrWithoutPeerId};
 
 pub use {
-    behaviour::{Behaviour, ExtendedBehaviour, ExtendedBehaviourBuilder, KadResult, NoopBehaviour},
+    behaviour::{Behaviour, CustomBehaviourBuilder, KadResult, NoopBehaviour},
     swarm::Connection,
 };
 
 /// Type alias for [`libp2p::Swarm`] running the [`behaviour::Behaviour`] with the given [`IpfsTypes`].
-pub type TSwarm<T> = Swarm<ExtendedBehaviour<T, NoopBehaviour>>;
-pub type TExtendedSwarm<T, Ext> = Swarm<ExtendedBehaviour<T, Ext>>;
+pub type TSwarm<T> = Swarm<Behaviour<T, NoopBehaviour>>;
+pub type TCustomSwarm<T, Custom> = Swarm<Behaviour<T, Custom>>;
 
 /// Defines the configuration for an IPFS swarm.
 pub struct SwarmOptions {
@@ -57,11 +57,11 @@ impl From<&IpfsOptions> for SwarmOptions {
 }
 
 /// Creates a new IPFS swarm.
-pub fn create_swarm<TIpfsTypes: IpfsTypes, Ext: NetworkBehaviour<OutEvent = ()>>(
+pub fn create_swarm<TIpfsTypes: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>>(
     options: SwarmOptions,
     span: Span,
-    behaviour: ExtendedBehaviour<TIpfsTypes, Ext>,
-) -> io::Result<TExtendedSwarm<TIpfsTypes, Ext>> {
+    behaviour: Behaviour<TIpfsTypes, Custom>,
+) -> io::Result<TCustomSwarm<TIpfsTypes, Custom>> {
     let peer_id = options.peer_id;
 
     // Set up an encrypted TCP transport over the Mplex protocol.

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -22,6 +22,8 @@ pub use {
 
 /// Type alias for [`libp2p::Swarm`] running the [`behaviour::Behaviour`] with the given [`IpfsTypes`].
 pub type TSwarm<T> = Swarm<Behaviour<T, NoopBehaviour>>;
+/// Type alias for [`libp2p::Swarm`] running the [`behaviour::Behaviour`] with the given [`IpfsTypes`],
+/// and a custom [`libp2p::swarm::NetworkBehaviour`].
 pub type TCustomSwarm<T, Custom> = Swarm<Behaviour<T, Custom>>;
 
 /// Defines the configuration for an IPFS swarm.


### PR DESCRIPTION
Allow the Ipfs NetworkBehaviour to be extended with a custom behaviour.