### PR TITLE
Make the ipfs transport extensible.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
 hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.39.1" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio", "relay"], version = "0.39.1" }
 multibase = { default-features = false, version = "0.9" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.8" }

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -145,7 +145,8 @@ fn main() {
         };
 
         // TODO: handle errors more gracefully.
-        let (ipfs, task): (Ipfs<ipfs::Types>, _) = UninitializedIpfs::new(opts)
+        let (ipfs, task): (Ipfs<ipfs::Types>, _) = opts.create_uninitialised_ipfs()
+            .expect("Failed to initialize transport.")
             .start()
             .await
             .expect("Initialization failed");

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -61,10 +61,7 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     let peer_id = options.peer_id;
 
     // Set up an encrypted TCP transport over the Mplex protocol.
-    let transport = transport::TransportBuilder::new(options.keypair.clone())?.build_transport();
-    //let upgrader = transport::TransportBuilder::new(options.keypair.clone())?.then();
-    //use crate::apply_upgrades;
-    //let transport = apply_upgrades!(upgrader =>);
+    let transport = transport::TransportBuilder::new(options.keypair.clone())?.build();
 
     // Create a Kademlia behaviour
     let behaviour = behaviour::build_behaviour(options, repo).await;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod addr;
 mod behaviour;
 pub(crate) mod pubsub;
 mod swarm;
-mod transport;
+pub mod transport;
 
 pub use addr::{MultiaddrWithPeerId, MultiaddrWithoutPeerId};
 pub use {behaviour::KadResult, swarm::Connection};
@@ -61,7 +61,10 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     let peer_id = options.peer_id;
 
     // Set up an encrypted TCP transport over the Mplex protocol.
-    let transport = transport::build_transport(options.keypair.clone())?;
+    let transport = transport::TransportBuilder::new(options.keypair.clone())?.build_transport();
+    //let upgrader = transport::TransportBuilder::new(options.keypair.clone())?.then();
+    //use crate::apply_upgrades;
+    //let transport = apply_upgrades!(upgrader =>);
 
     // Create a Kademlia behaviour
     let behaviour = behaviour::build_behaviour(options, repo).await;

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -582,7 +582,7 @@ mod tests {
     fn build_swarm() -> (PeerId, libp2p::swarm::Swarm<SwarmApi>) {
         let key = Keypair::generate_ed25519();
         let peer_id = key.public().into_peer_id();
-        let transport = TransportBuilder::new(key).unwrap().build_transport();
+        let transport = TransportBuilder::new(key).unwrap().build();
 
         let swarm = SwarmBuilder::new(transport, SwarmApi::default(), peer_id)
             .executor(Box::new(ThreadLocalTokio))

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -414,7 +414,7 @@ fn connection_point_addr(cp: &ConnectedPoint) -> MultiaddrWithoutPeerId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::p2p::transport::build_transport;
+    use crate::p2p::transport::TransportBuilder;
     use futures::{
         stream::{StreamExt, TryStreamExt},
         TryFutureExt,
@@ -582,7 +582,7 @@ mod tests {
     fn build_swarm() -> (PeerId, libp2p::swarm::Swarm<SwarmApi>) {
         let key = Keypair::generate_ed25519();
         let peer_id = key.public().into_peer_id();
-        let transport = build_transport(key).unwrap();
+        let transport = TransportBuilder::new(key).unwrap().build_transport();
 
         let swarm = SwarmBuilder::new(transport, SwarmApi::default(), peer_id)
             .executor(Box::new(ThreadLocalTokio))

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -44,13 +44,13 @@
 //!     .apply(upgrade)
 //!     .build();
 //! ```
-use futures::{AsyncRead, AsyncWrite, Future};
+use futures::{AsyncRead, AsyncWrite, Future, TryFutureExt};
 use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::and_then::AndThen;
 use libp2p::core::transport::upgrade::{Authenticate, Authenticated, Version};
 use libp2p::core::transport::{Boxed, OrTransport, Upgrade};
 use libp2p::core::upgrade::SelectUpgrade;
-use libp2p::core::{ConnectedPoint, Negotiated};
+use libp2p::core::{ConnectedPoint, Negotiated, UpgradeInfo};
 use libp2p::dns::{GenDnsConfig, TokioDnsConfig};
 use libp2p::mplex::MplexConfig;
 use libp2p::noise::{self, NoiseAuthenticated, NoiseConfig, X25519Spec, XX};
@@ -74,6 +74,7 @@ pub type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
 /// extend the base IPFS transport implementation, then you do not need to use this builder and can
 /// instead construct your [UninitializedIpfs](`crate::UninitializedIpfs`) directly from
 /// [IpfsOptions](`crate::IpfsOptions`).
+#[derive(Clone)]
 pub struct TransportBuilder<T> {
     keypair: identity::Keypair,
     transport: T,
@@ -96,7 +97,6 @@ impl<T> TransportBuilder<T>
 where
     T: Transport + Clone + Send + Sync + 'static,
     T::Dial: Send,
-    T::Error: 'static,
     T::Error: Send + Sync + 'static,
     T::Listener: Send,
     T::ListenerUpgrade: Send,
@@ -121,9 +121,16 @@ where
         )
     }
 
-    pub fn then(
-        self,
-    ) -> TransportUpgrader<
+    pub fn map_auth(self) -> TransportAuthMapper<T, NoiseAuthenticated<XX, X25519Spec, ()>>
+    {
+        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
+            .into_authentic(&self.keypair)
+            .unwrap();
+        let noise_auth = NoiseConfig::xx(xx_keypair).into_authenticated();
+        TransportAuthMapper { transport: self.transport, auth: noise_auth }
+    }
+
+    pub fn apply_upgrades(self) -> TransportUpgrader<
         AndThen<
             T,
             impl Clone
@@ -134,29 +141,83 @@ where
                     -> Authenticate<T::Output, NoiseAuthenticated<XX, X25519Spec, ()>>,
         >,
     > {
-        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
-            .into_authentic(&self.keypair)
-            .unwrap();
-        let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
-        TransportUpgrader {
-            authenticated: self
-                .transport
-                .upgrade(Version::V1)
-                .authenticate(noise_config),
-        }
+        self.map_auth().apply_upgrades()
     }
 
     /// Builds the transport that serves as a common ground for all connections.
     ///
     /// Set up an encrypted TCP transport over the Mplex protocol.
     pub fn build(self) -> TTransport {
-        self.then().build()
+        self.map_auth().apply_upgrades().build()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TransportAuthMapper<T, A> 
+{
+    transport: T,
+    auth: A,
+}
+
+impl<T, A, C, E, F> TransportAuthMapper<T, A> 
+where
+    T: Transport + Clone + Send + Sync + 'static,
+    T::Dial: Send,
+    T::Error: Send + Sync + 'static,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    T::Output: AsyncWrite + AsyncRead + Unpin + Send + 'static,
+    A: Clone + Send + Sync + 'static,
+    A: InboundUpgrade<Negotiated<T::Output>, Output = (PeerId, C), Error = E, Future = F>,
+    A: OutboundUpgrade<Negotiated<T::Output>, Output = (PeerId, C), Error = E, Future = F>,
+    <A as UpgradeInfo>::Info: Send,
+    <<A as UpgradeInfo>::InfoIter as IntoIterator>::IntoIter: Send,
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    E: Send + Sync + StdError + 'static,
+    F: Send + 'static,
+{
+    pub fn map_inbound<Fun>(self, fun: Fun) -> TransportAuthMapper<T, TryMapInboundUpgrade<A, Fun>>
+    where
+    {
+        let auth = TryMapInboundUpgrade{ upgrade: self.auth, fun };
+        TransportAuthMapper{transport: self.transport, auth }
+    } 
+
+    pub fn map_outbound<Fun>(self, fun: Fun) -> TransportAuthMapper<T, TryMapOutboundUpgrade<A, Fun>>
+    where
+    {
+        let auth = TryMapOutboundUpgrade{ upgrade: self.auth, fun };
+        TransportAuthMapper{transport: self.transport, auth }
+    } 
+
+    pub fn apply_upgrades(self) -> TransportUpgrader<
+        AndThen<
+            T,
+            impl Clone
+                + FnOnce(
+                    T::Output,
+                    ConnectedPoint,
+                )
+                    -> Authenticate<T::Output, A>,
+        >,
+    >
+    {
+        TransportUpgrader { authenticated: self.transport.upgrade(Version::V1).authenticate(self.auth) }
+    }
+
+
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
+    pub fn build(self) -> TTransport {
+        self.apply_upgrades().build()
     }
 }
 
 /// Upgrader for IPFS Transports.
 /// 
 /// Facilitates the application of [Upgrades](`Upgrade`) to the transport.
+#[derive(Clone)]
 pub struct TransportUpgrader<T> {
     authenticated: Authenticated<T>,
 }
@@ -183,6 +244,10 @@ where
         TransportUpgrader { authenticated }
     }
 
+
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
     pub fn build(self) -> TTransport {
         self.authenticated
             .multiplex(SelectUpgrade::new(
@@ -193,5 +258,81 @@ where
             .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
             .map_err(|err| Error::new(ErrorKind::Other, err))
             .boxed()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TryMapInboundUpgrade<U, F>
+{
+    upgrade: U,
+    fun: F,
+}
+
+impl<U, F> UpgradeInfo for TryMapInboundUpgrade<U, F>
+where
+  U: UpgradeInfo
+{
+    type Info = U::Info;
+
+    type InfoIter = U::InfoIter;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        self.upgrade.protocol_info()
+    }
+}
+
+impl<U, F, T, Fut, D> InboundUpgrade<T> for TryMapInboundUpgrade<U, F> 
+where
+    U: InboundUpgrade<T>,
+    F: FnOnce(U::Output) -> Fut,
+    Fut: Future<Output = Result<D, U::Error>>,
+  {
+    type Output = D;
+
+    type Error = U::Error;
+
+    type Future = futures::future::AndThen<U::Future, Fut, F>;
+
+
+    fn upgrade_inbound(self, socket: T, info: Self::Info) -> Self::Future {
+        self.upgrade.upgrade_inbound(socket, info).and_then( self.fun )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TryMapOutboundUpgrade<U, F>
+{
+    upgrade: U,
+    fun: F,
+}
+
+impl<U, F> UpgradeInfo for TryMapOutboundUpgrade<U, F>
+where
+  U: UpgradeInfo
+{
+    type Info = U::Info;
+
+    type InfoIter = U::InfoIter;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        self.upgrade.protocol_info()
+    }
+}
+
+impl<U, F, T, Fut, D> OutboundUpgrade<T> for TryMapOutboundUpgrade<U, F> 
+where
+    U: OutboundUpgrade<T>,
+    F: FnOnce(U::Output) -> Fut,
+    Fut: Future<Output = Result<D, U::Error>>,
+  {
+    type Output = D;
+
+    type Error = U::Error;
+
+    type Future = futures::future::AndThen<U::Future, Fut, F>;
+
+
+    fn upgrade_outbound(self, socket: T, info: Self::Info) -> Self::Future {
+        self.upgrade.upgrade_outbound(socket, info).and_then( self.fun )
     }
 }

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -1,12 +1,59 @@
+//! Construction of [Transports](`libp2p::Transport`) for IPFS.
+//! 
+//! This module is only needed if you need to extend the functionality of the underlying
+//! [Transport](`libp2p::Transport`).
+//!
+//! The base IPFS transport can be extended using [`TransportBuilder::or`] to wrap the base
+//! transport implementation inside another (see [`OrTransport`]):
+//!
+//! ```
+//! use ipfs::p2p::transport::{TTransport, TransportBuilder};
+//! use libp2p::core::transport::MemoryTransport;
+//! use libp2p::identity::Keypair;
+//! let keypair: Keypair = Keypair::generate_ed25519();
+//! let transport: TTransport = TransportBuilder::new(keypair).unwrap()
+//!     .or(MemoryTransport::default())
+//!     .build();
+//! ```
+//!
+//! To perform additional [Upgrades](`Upgrade`) on the connection, first apply any Transport
+//! extensions, use [`TransportBuilder::then`] to convert this builder into a [`TransportUpgrader`]
+//! , and then [apply](`TransportUpgrader::apply`) upgrades:
+//! 
+//! ```
+//! use ipfs::p2p::transport::{TTransport, TransportBuilder};
+//! use libp2p::core::upgrade;
+//! use libp2p::identity::Keypair;
+//! use std::io;
+//! let keypair: Keypair = Keypair::generate_ed25519();
+//! let upgrade = upgrade::from_fn("/foo/1", move |mut sock: upgrade::Negotiated<_>, endpoint| async move {
+//!     if endpoint.is_dialer() {
+//!         upgrade::write_length_prefixed(&mut sock, "some handshake data").await?;
+//!         # use futures::AsyncWriteExt;
+//!         sock.close().await?;
+//!     } else {
+//!         let handshake_data = upgrade::read_length_prefixed(&mut sock, 1024).await?;
+//!         if handshake_data != b"some handshake data" {
+//!             return Err(io::Error::new(io::ErrorKind::Other, "bad handshake"));
+//!         }
+//!     }
+//!     Ok(sock)
+//! });
+//! let transport: TTransport = TransportBuilder::new(keypair).unwrap()
+//!     .then()
+//!     .apply(upgrade)
+//!     .build();
+//! ```
 use futures::{AsyncRead, AsyncWrite, Future};
 use libp2p::core::muxing::StreamMuxerBox;
-use libp2p::core::transport::upgrade::{Builder, Version};
-use libp2p::core::transport::{Boxed, OrTransport};
+use libp2p::core::transport::and_then::AndThen;
+use libp2p::core::transport::upgrade::{Authenticate, Authenticated, Version};
+use libp2p::core::transport::{Boxed, OrTransport, Upgrade};
 use libp2p::core::upgrade::SelectUpgrade;
-use libp2p::core::{Negotiated, UpgradeInfo};
+use libp2p::core::{ConnectedPoint, Negotiated};
 use libp2p::dns::{GenDnsConfig, TokioDnsConfig};
 use libp2p::mplex::MplexConfig;
-use libp2p::noise::{self, NoiseAuthenticated, NoiseConfig, NoiseOutput, X25519Spec, XX};
+use libp2p::noise::{self, NoiseAuthenticated, NoiseConfig, X25519Spec, XX};
 use libp2p::relay::{Relay, RelayTransport};
 use libp2p::tcp::tokio::Tcp;
 use libp2p::tcp::{GenTcpConfig, TokioTcpConfig};
@@ -19,9 +66,15 @@ use std::time::Duration;
 use trust_dns_resolver::name_server::{GenericConnection, GenericConnectionProvider, TokioRuntime};
 
 /// Transport type.
-pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
+pub type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
-pub struct TransportBuilder<T: Transport> {
+/// Builder for IPFS Transports.
+///
+/// This type can be used to build IPFS compatible Transport implementations. If you do not need to
+/// extend the base IPFS transport implementation, then you do not need to use this builder and can
+/// instead construct your [UninitializedIpfs](`crate::UninitializedIpfs`) directly from
+/// [IpfsOptions](`crate::IpfsOptions`).
+pub struct TransportBuilder<T> {
     keypair: identity::Keypair,
     transport: T,
 }
@@ -39,9 +92,15 @@ impl
     }
 }
 
-impl<T: Transport> TransportBuilder<T>
+impl<T> TransportBuilder<T>
 where
-    <T as Transport>::Error: 'static,
+    T: Transport + Clone + Send + Sync + 'static,
+    T::Dial: Send,
+    T::Error: 'static,
+    T::Error: Send + Sync + 'static,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    T::Output: AsyncWrite + AsyncRead + Unpin + Send + 'static,
 {
     pub fn or<O: Transport>(self, other: O) -> TransportBuilder<OrTransport<O, T>> {
         TransportBuilder {
@@ -49,9 +108,7 @@ where
             transport: other.or_transport(self.transport),
         }
     }
-}
 
-impl<T: Transport + Clone> TransportBuilder<T> {
     pub fn relay(self) -> (TransportBuilder<RelayTransport<T>>, Relay) {
         let (transport, relay) =
             libp2p::relay::new_transport_and_behaviour(Default::default(), self.transport);
@@ -63,143 +120,78 @@ impl<T: Transport + Clone> TransportBuilder<T> {
             relay,
         )
     }
-}
 
-impl<T: Transport + Clone + Send + Sync + 'static> TransportBuilder<T>
-where
-    <T as Transport>::Error: Send + Sync + 'static,
-    <T as Transport>::Output: AsyncWrite + AsyncRead + Unpin + Send + 'static,
-    <T as Transport>::Listener: Send,
-    <T as Transport>::ListenerUpgrade: Send,
-    <T as Transport>::Dial: Send,
-{
-    /// Builds the transport that serves as a common ground for all connections.
-    ///
-    /// Set up an encrypted TCP transport over the Mplex protocol.
-    pub fn build_transport(self) -> TTransport {
+    pub fn then(
+        self,
+    ) -> TransportUpgrader<
+        AndThen<
+            T,
+            impl Clone
+                + FnOnce(
+                    T::Output,
+                    ConnectedPoint,
+                )
+                    -> Authenticate<T::Output, NoiseAuthenticated<XX, X25519Spec, ()>>,
+        >,
+    > {
         let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
             .into_authentic(&self.keypair)
             .unwrap();
         let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
-        self.transport
-            .upgrade(Version::V1)
-            .authenticate(noise_config)
-            .multiplex(SelectUpgrade::new(
-                YamuxConfig::default(),
-                MplexConfig::new(),
-            ))
-            .timeout(Duration::from_secs(20))
-            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-            .map_err(|err| Error::new(ErrorKind::Other, err))
-            .boxed()
-    }
-
-    /// Builds the transport that serves as a common ground for all connections.
-    ///
-    /// Set up an encrypted TCP transport over the Mplex protocol.
-    pub fn build_transport_with_upgrade<U, D, E, F, I, It>(self, upgrade: U) -> TTransport
-    where
-        D: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-        E: StdError + Send + Sync + 'static,
-        F: Future + Send + Sync,
-        I: IntoIterator<IntoIter = It>,
-        It: Send + Sync + Iterator,
-        <It as Iterator>::Item: Send + Sync,
-        U: Send + Sync + Clone + 'static,
-        U: InboundUpgrade<
-            Negotiated<NoiseOutput<Negotiated<<T as Transport>::Output>>>,
-            Output = D,
-            Error = E,
-            Future = F,
-        >,
-        U: OutboundUpgrade<
-            Negotiated<NoiseOutput<Negotiated<<T as Transport>::Output>>>,
-            Output = D,
-            Error = E,
-            Future = F,
-        >,
-        U: UpgradeInfo<InfoIter = I>,
-        <U as UpgradeInfo>::Info: Send,
-    {
-        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
-            .into_authentic(&self.keypair)
-            .unwrap();
-        let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
-        self.transport
-            .upgrade(Version::V1)
-            .authenticate(noise_config)
-            .apply(upgrade)
-            .multiplex(SelectUpgrade::new(
-                YamuxConfig::default(),
-                MplexConfig::new(),
-            ))
-            .timeout(Duration::from_secs(20))
-            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-            .map_err(|err| Error::new(ErrorKind::Other, err))
-            .boxed()
-    }
-}
-
-pub mod apply_upgrades {
-    use super::{
-        noise, Builder, NoiseAuthenticated, NoiseConfig, TransportBuilder, X25519Spec, XX,
-    };
-
-    pub use std::{
-        io::{Error, ErrorKind},
-        time::Duration,
-    };
-
-    pub use libp2p::{
-        core::{
-            muxing::StreamMuxerBox,
-            upgrade::{SelectUpgrade, Version},
-        },
-        mplex::MplexConfig,
-        yamux::YamuxConfig,
-        Transport,
-    };
-
-    impl<T: Transport> TransportBuilder<T>
-    where
-        <T as Transport>::Error: 'static,
-    {
-        pub fn then(self) -> TransportUpgrader<T> {
-            let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
-                .into_authentic(&self.keypair)
-                .unwrap();
-            let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
-            TransportUpgrader {
-                noise_config,
-                builder: self.transport.upgrade(Version::V1),
-            }
+        TransportUpgrader {
+            authenticated: self
+                .transport
+                .upgrade(Version::V1)
+                .authenticate(noise_config),
         }
     }
 
-    pub struct TransportUpgrader<T: Transport> {
-        pub noise_config: NoiseAuthenticated<XX, X25519Spec, ()>,
-        pub builder: Builder<T>,
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
+    pub fn build(self) -> TTransport {
+        self.then().build()
+    }
+}
+
+/// Upgrader for IPFS Transports.
+/// 
+/// Facilitates the application of [Upgrades](`Upgrade`) to the transport.
+pub struct TransportUpgrader<T> {
+    authenticated: Authenticated<T>,
+}
+
+impl<T, C> TransportUpgrader<T>
+where
+    T: Transport<Output = (PeerId, C)> + Clone + Send + Sync + 'static,
+    T::Dial: Send,
+    T::Error: Send + Sync + 'static,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    pub fn apply<U, D, E, F>(self, u: U) -> TransportUpgrader<Upgrade<T, U>>
+    where
+        U: InboundUpgrade<Negotiated<C>, Output = D, Error = E, Future = F>,
+        U: OutboundUpgrade<Negotiated<C>, Output = D, Error = E, Future = F>,
+        U: Clone,
+        D: AsyncRead + AsyncWrite + Unpin,
+        E: StdError + 'static,
+        F: Future,
+    {
+        let authenticated = self.authenticated.apply(u);
+        TransportUpgrader { authenticated }
     }
 
-    #[macro_export]
-    macro_rules! apply_upgrades {
-        ($upgrader:expr => $($upgrades:expr),*) => {
-            {
-                use $crate::p2p::transport::apply_upgrades::*;
-                $upgrader.builder
-                    .authenticate($upgrader.noise_config)
-                    $(
-                        .apply($upgrades)
-                    )*
-                    .multiplex(SelectUpgrade::new(
-                        YamuxConfig::default(),
-                        MplexConfig::new(),
-                    ))
-                    .timeout(Duration::from_secs(20))
-                    .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-                    .map_err(|err| Error::new(ErrorKind::Other, err))
-                    .boxed()
-            }
-        };
+    pub fn build(self) -> TTransport {
+        self.authenticated
+            .multiplex(SelectUpgrade::new(
+                YamuxConfig::default(),
+                MplexConfig::new(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+            .map_err(|err| Error::new(ErrorKind::Other, err))
+            .boxed()
     }
 }

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -1,38 +1,205 @@
+use futures::{AsyncRead, AsyncWrite, Future};
 use libp2p::core::muxing::StreamMuxerBox;
-use libp2p::core::transport::upgrade::Version;
-use libp2p::core::transport::Boxed;
+use libp2p::core::transport::upgrade::{Builder, Version};
+use libp2p::core::transport::{Boxed, OrTransport};
 use libp2p::core::upgrade::SelectUpgrade;
-use libp2p::dns::TokioDnsConfig;
-use libp2p::identity;
+use libp2p::core::{Negotiated, UpgradeInfo};
+use libp2p::dns::{GenDnsConfig, TokioDnsConfig};
 use libp2p::mplex::MplexConfig;
-use libp2p::noise::{self, NoiseConfig};
-use libp2p::tcp::TokioTcpConfig;
+use libp2p::noise::{self, NoiseAuthenticated, NoiseConfig, NoiseOutput, X25519Spec, XX};
+use libp2p::relay::{Relay, RelayTransport};
+use libp2p::tcp::tokio::Tcp;
+use libp2p::tcp::{GenTcpConfig, TokioTcpConfig};
 use libp2p::yamux::YamuxConfig;
+use libp2p::{identity, InboundUpgrade, OutboundUpgrade};
 use libp2p::{PeerId, Transport};
+use std::error::Error as StdError;
 use std::io::{self, Error, ErrorKind};
 use std::time::Duration;
+use trust_dns_resolver::name_server::{GenericConnection, GenericConnectionProvider, TokioRuntime};
 
 /// Transport type.
 pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
-/// Builds the transport that serves as a common ground for all connections.
-///
-/// Set up an encrypted TCP transport over the Mplex protocol.
-pub fn build_transport(keypair: identity::Keypair) -> io::Result<TTransport> {
-    let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
-        .into_authentic(&keypair)
-        .unwrap();
-    let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
+pub struct TransportBuilder<T: Transport> {
+    keypair: identity::Keypair,
+    transport: T,
+}
 
-    Ok(TokioDnsConfig::system(TokioTcpConfig::new())?
-        .upgrade(Version::V1)
-        .authenticate(noise_config)
-        .multiplex(SelectUpgrade::new(
-            YamuxConfig::default(),
-            MplexConfig::new(),
-        ))
-        .timeout(Duration::from_secs(20))
-        .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-        .map_err(|err| Error::new(ErrorKind::Other, err))
-        .boxed())
+impl
+    TransportBuilder<
+        GenDnsConfig<GenTcpConfig<Tcp>, GenericConnection, GenericConnectionProvider<TokioRuntime>>,
+    >
+{
+    pub fn new(keypair: identity::Keypair) -> io::Result<Self> {
+        Ok(Self {
+            keypair,
+            transport: TokioDnsConfig::system(TokioTcpConfig::new())?,
+        })
+    }
+}
+
+impl<T: Transport> TransportBuilder<T>
+where
+    <T as Transport>::Error: 'static,
+{
+    pub fn or<O: Transport>(self, other: O) -> TransportBuilder<OrTransport<O, T>> {
+        TransportBuilder {
+            keypair: self.keypair,
+            transport: other.or_transport(self.transport),
+        }
+    }
+}
+
+impl<T: Transport + Clone> TransportBuilder<T> {
+    pub fn relay(self) -> (TransportBuilder<RelayTransport<T>>, Relay) {
+        let (transport, relay) =
+            libp2p::relay::new_transport_and_behaviour(Default::default(), self.transport);
+        (
+            TransportBuilder {
+                keypair: self.keypair,
+                transport,
+            },
+            relay,
+        )
+    }
+}
+
+impl<T: Transport + Clone + Send + Sync + 'static> TransportBuilder<T>
+where
+    <T as Transport>::Error: Send + Sync + 'static,
+    <T as Transport>::Output: AsyncWrite + AsyncRead + Unpin + Send + 'static,
+    <T as Transport>::Listener: Send,
+    <T as Transport>::ListenerUpgrade: Send,
+    <T as Transport>::Dial: Send,
+{
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
+    pub fn build_transport(self) -> TTransport {
+        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
+            .into_authentic(&self.keypair)
+            .unwrap();
+        let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
+        self.transport
+            .upgrade(Version::V1)
+            .authenticate(noise_config)
+            .multiplex(SelectUpgrade::new(
+                YamuxConfig::default(),
+                MplexConfig::new(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+            .map_err(|err| Error::new(ErrorKind::Other, err))
+            .boxed()
+    }
+
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
+    pub fn build_transport_with_upgrade<U, D, E, F, I, It>(self, upgrade: U) -> TTransport
+    where
+        D: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        E: StdError + Send + Sync + 'static,
+        F: Future + Send + Sync,
+        I: IntoIterator<IntoIter = It>,
+        It: Send + Sync + Iterator,
+        <It as Iterator>::Item: Send + Sync,
+        U: Send + Sync + Clone + 'static,
+        U: InboundUpgrade<
+            Negotiated<NoiseOutput<Negotiated<<T as Transport>::Output>>>,
+            Output = D,
+            Error = E,
+            Future = F,
+        >,
+        U: OutboundUpgrade<
+            Negotiated<NoiseOutput<Negotiated<<T as Transport>::Output>>>,
+            Output = D,
+            Error = E,
+            Future = F,
+        >,
+        U: UpgradeInfo<InfoIter = I>,
+        <U as UpgradeInfo>::Info: Send,
+    {
+        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
+            .into_authentic(&self.keypair)
+            .unwrap();
+        let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
+        self.transport
+            .upgrade(Version::V1)
+            .authenticate(noise_config)
+            .apply(upgrade)
+            .multiplex(SelectUpgrade::new(
+                YamuxConfig::default(),
+                MplexConfig::new(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+            .map_err(|err| Error::new(ErrorKind::Other, err))
+            .boxed()
+    }
+}
+
+pub mod apply_upgrades {
+    use super::{
+        noise, Builder, NoiseAuthenticated, NoiseConfig, TransportBuilder, X25519Spec, XX,
+    };
+
+    pub use std::{
+        io::{Error, ErrorKind},
+        time::Duration,
+    };
+
+    pub use libp2p::{
+        core::{
+            muxing::StreamMuxerBox,
+            upgrade::{SelectUpgrade, Version},
+        },
+        mplex::MplexConfig,
+        yamux::YamuxConfig,
+        Transport,
+    };
+
+    impl<T: Transport> TransportBuilder<T>
+    where
+        <T as Transport>::Error: 'static,
+    {
+        pub fn then(self) -> TransportUpgrader<T> {
+            let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
+                .into_authentic(&self.keypair)
+                .unwrap();
+            let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
+            TransportUpgrader {
+                noise_config,
+                builder: self.transport.upgrade(Version::V1),
+            }
+        }
+    }
+
+    pub struct TransportUpgrader<T: Transport> {
+        pub noise_config: NoiseAuthenticated<XX, X25519Spec, ()>,
+        pub builder: Builder<T>,
+    }
+
+    #[macro_export]
+    macro_rules! apply_upgrades {
+        ($upgrader:expr => $($upgrades:expr),*) => {
+            {
+                use $crate::p2p::transport::apply_upgrades::*;
+                $upgrader.builder
+                    .authenticate($upgrader.noise_config)
+                    $(
+                        .apply($upgrades)
+                    )*
+                    .multiplex(SelectUpgrade::new(
+                        YamuxConfig::default(),
+                        MplexConfig::new(),
+                    ))
+                    .timeout(Duration::from_secs(20))
+                    .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+                    .map_err(|err| Error::new(ErrorKind::Other, err))
+                    .boxed()
+            }
+        };
+    }
 }


### PR DESCRIPTION
I've implemented two methods to do this.

The first is with the `build_transport` and `build_transport_with_upgrade` methods. The latter of those creates a ipfs-compatible transport with custom transport layers and a single custom upgrade.

The second method is within the `apply_upgrades` submodule. This contains a macro (apply_upgrades) which allows the user to apply any number of upgrades when building the transport.

The first method is I think clearer and easier to use, however it doesn't allow more than one upgrade to be applies. The pros and cons are switched for the second method. Thoughts?