### PR TITLE
Update kepler-staging with behaviour and transport changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
 libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio", "relay"], version = "0.39.1" }
 libipld = "0.12"
-prost = { default-features = false, version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
 thiserror = { default-features = false, version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
 libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio", "relay"], version = "0.39.1" }
 libipld = "0.12"
-multibase = { default-features = false, version = "0.9" }
-multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
 hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.39.1" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio", "relay"], version = "0.39.1" }
 multibase = { default-features = false, version = "0.9" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.8" }

--- a/examples/dag_creation.rs
+++ b/examples/dag_creation.rs
@@ -1,5 +1,5 @@
 use futures::join;
-use ipfs::{Ipfs, IpfsOptions, IpfsPath, TestTypes, UninitializedIpfs};
+use ipfs::{Ipfs, IpfsOptions, IpfsPath, TestTypes};
 use libipld::ipld;
 use tokio::task;
 
@@ -8,8 +8,12 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // Initialize the repo and start a daemon
-    let opts = IpfsOptions::inmemory_with_generated_keys();
-    let (ipfs, fut): (Ipfs<TestTypes>, _) = UninitializedIpfs::new(opts).start().await.unwrap();
+    let (ipfs, fut): (Ipfs<TestTypes>, _) = IpfsOptions::inmemory_with_generated_keys()
+        .create_uninitialised_ipfs()
+        .unwrap()
+        .start()
+        .await
+        .unwrap();
     task::spawn(fut);
 
     // Create a DAG

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -1,6 +1,6 @@
 use futures::pin_mut;
 use futures::stream::StreamExt; // needed for StreamExt::next
-use ipfs::{Error, Ipfs, IpfsOptions, IpfsPath, MultiaddrWithPeerId, TestTypes, UninitializedIpfs};
+use ipfs::{Error, Ipfs, IpfsOptions, IpfsPath, MultiaddrWithPeerId, TestTypes};
 use std::env;
 use std::process::exit;
 use tokio::io::AsyncWriteExt;
@@ -50,7 +50,7 @@ async fn main() {
 
     // UninitializedIpfs will handle starting up the repository and return the facade (ipfs::Ipfs)
     // and the background task (ipfs::IpfsFuture).
-    let (ipfs, fut): (Ipfs<TestTypes>, _) = UninitializedIpfs::new(opts).start().await.unwrap();
+    let (ipfs, fut): (Ipfs<TestTypes>, _) = opts.create_uninitialised_ipfs().unwrap().start().await.unwrap();
 
     // The background task must be spawned to use anything other than the repository; most notably,
     // the libp2p.

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -145,7 +145,8 @@ fn main() {
         };
 
         // TODO: handle errors more gracefully.
-        let (ipfs, task): (Ipfs<ipfs::Types>, _) = UninitializedIpfs::new(opts)
+        let (ipfs, task): (Ipfs<ipfs::Types>, _) = opts.create_uninitialised_ipfs()
+            .expect("Failed to initialize transport.")
             .start()
             .await
             .expect("Initialization failed");

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -174,11 +174,15 @@ mod tests {
     async fn testing_routes(
     ) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
         use super::routes;
-        use ipfs::{IpfsOptions, UninitializedIpfs};
+        use ipfs::IpfsOptions;
 
         let options = IpfsOptions::inmemory_with_generated_keys();
-        let (ipfs, _): (Ipfs<TestTypes>, _) =
-            UninitializedIpfs::new(options).start().await.unwrap();
+        let (ipfs, _): (Ipfs<TestTypes>, _) = options
+            .create_uninitialised_ipfs()
+            .unwrap()
+            .start()
+            .await
+            .unwrap();
 
         let (shutdown_tx, _) = tokio::sync::mpsc::channel::<()>(1);
 

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -406,7 +406,7 @@ mod tests {
 
     async fn tokio_ipfs() -> ipfs::Ipfs<ipfs::TestTypes> {
         let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
-        let (ipfs, fut) = ipfs::UninitializedIpfs::new(options).start().await.unwrap();
+        let (ipfs, fut) = options.create_uninitialised_ipfs().unwrap().start().await.unwrap();
 
         tokio::spawn(fut);
         ipfs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ use futures::{
     stream::{Fuse, Stream},
 };
 use libp2p::swarm::NetworkBehaviour;
-use p2p::{ExtendedBehaviourBuilder, TExtendedSwarm};
+use p2p::{CustomBehaviourBuilder, TCustomSwarm};
 use tracing::Span;
 use tracing_futures::Instrument;
 
@@ -313,7 +313,7 @@ enum IpfsEvent {
 
 pub type UninitializedIpfs<Types> = UninitializedExtendedIpfs<Types, p2p::NoopBehaviour>;
 
-impl<Types: IpfsTypes> UninitializedIpfs<Types> {
+impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
     /// Configures a new UninitializedIpfs with from the given options and optionally a span.
     /// If the span is not given, it is defaulted to `tracing::trace_span!("ipfs")`.
     ///
@@ -344,54 +344,54 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             ipfs,
             receiver,
             repo_events,
-            behaviour: p2p::ExtendedBehaviour::new(swarm_options, arc_repo),
+            behaviour: p2p::Behaviour::new(swarm_options, arc_repo),
             options: options,
         }
     }
 }
 
-pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Behaviour: NetworkBehaviour> {
+pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     repo: Arc<Repo<Types>>,
     ipfs: Ipfs<Types>,
     receiver: Receiver<IpfsEvent>,
     repo_events: Receiver<RepoEvent>,
-    behaviour: p2p::ExtendedBehaviour<Types, Behaviour>,
+    behaviour: p2p::Behaviour<Types, Custom>,
     options: IpfsOptions,
 }
 
 impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
     UninitializedExtendedIpfs<Types, Behaviour>
 {
-    pub fn with_extended_behaviour<Ext: NetworkBehaviour>(
+    pub fn with_extended_behaviour<Custom: NetworkBehaviour<OutEvent = ()>>(
         self,
-        behaviour: Ext,
-    ) -> UninitializedExtendedIpfs<Types, Ext> {
+        behaviour: Custom,
+    ) -> UninitializedExtendedIpfs<Types, Custom> {
         UninitializedExtendedIpfs {
             repo: self.repo,
             ipfs: self.ipfs,
             receiver: self.receiver,
             repo_events: self.repo_events,
-            behaviour: self.behaviour.new_extended_behaviour(behaviour),
             options: self.options,
+            behaviour: self.behaviour.new_custom_behaviour(behaviour),
         }
     }
 
-    pub fn with_extended_behaviour_from_builder<Ext, ExtBuilder>(
+    pub fn with_extended_behaviour_from_builder<Custom, CustomBuilder>(
         self,
-        behaviour_builder: ExtBuilder,
-    ) -> UninitializedExtendedIpfs<Types, Ext>
+        behaviour_builder: CustomBuilder,
+    ) -> UninitializedExtendedIpfs<Types, Custom>
     where
-        Ext: NetworkBehaviour<OutEvent = ()>,
-        ExtBuilder: ExtendedBehaviourBuilder<Types, Ext>,
+        Custom: NetworkBehaviour<OutEvent = ()>,
+        CustomBuilder: CustomBehaviourBuilder<Types, Custom>,
     {
-        let behaviour = behaviour_builder.build(self.ipfs.clone());
+        let custom = behaviour_builder.build(self.ipfs.clone());
         UninitializedExtendedIpfs {
             repo: self.repo,
             ipfs: self.ipfs,
             receiver: self.receiver,
             repo_events: self.repo_events,
-            behaviour: self.behaviour.new_extended_behaviour(behaviour),
             options: self.options,
+            behaviour: self.behaviour.new_custom_behaviour(custom),
         }
     }
     /// Initialize the ipfs node. The returned `Ipfs` value is cloneable, send and sync, and the
@@ -440,7 +440,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
             listening_addrs, ..
         } = options;
 
-        let mut fut = IpfsFuture {
+        let mut fut: IpfsFuture<Types, Behaviour> = IpfsFuture {
             repo_events: repo_events.fuse(),
             from_facade: receiver.fuse(),
             swarm,
@@ -1273,7 +1273,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
 /// Background task of `Ipfs` created when calling `UninitializedIpfs::start`.
 // The receivers are Fuse'd so that we don't have to manage state on them being exhausted.
 struct IpfsFuture<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> {
-    swarm: TExtendedSwarm<Types, Behaviour>,
+    swarm: TCustomSwarm<Types, Behaviour>,
     repo_events: Fuse<Receiver<RepoEvent>>,
     from_facade: Fuse<Receiver<IpfsEvent>>,
     listening_addresses: HashMap<Multiaddr, (ListenerId, Option<Channel<Multiaddr>>)>,
@@ -1451,11 +1451,11 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
 
                 match inner {
                     IpfsEvent::Connect(target, ret) => {
-                        ret.send(self.swarm.behaviour_mut().inner.connect(target))
+                        ret.send(self.swarm.behaviour_mut().connect(target))
                             .ok();
                     }
                     IpfsEvent::Addresses(ret) => {
-                        let addrs = self.swarm.behaviour_mut().inner.addrs();
+                        let addrs = self.swarm.behaviour_mut().addrs();
                         ret.send(Ok(addrs)).ok();
                     }
                     IpfsEvent::Listeners(ret) => {
@@ -1463,12 +1463,12 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         ret.send(Ok(listeners)).ok();
                     }
                     IpfsEvent::Connections(ret) => {
-                        let connections = self.swarm.behaviour_mut().inner.connections();
+                        let connections = self.swarm.behaviour_mut().connections();
                         ret.send(Ok(connections.collect())).ok();
                     }
                     IpfsEvent::Disconnect(addr, ret) => {
                         if let Some(disconnector) =
-                            self.swarm.behaviour_mut().inner.disconnect(addr)
+                            self.swarm.behaviour_mut().disconnect(addr)
                         {
                             disconnector.disconnect(&mut self.swarm);
                         }
@@ -1485,16 +1485,16 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                     }
                     IpfsEvent::PubsubSubscribe(topic, ret) => {
                         let _ =
-                            ret.send(self.swarm.behaviour_mut().inner.pubsub().subscribe(topic));
+                            ret.send(self.swarm.behaviour_mut().pubsub().subscribe(topic));
                     }
                     IpfsEvent::PubsubUnsubscribe(topic, ret) => {
                         let _ =
-                            ret.send(self.swarm.behaviour_mut().inner.pubsub().unsubscribe(topic));
+                            ret.send(self.swarm.behaviour_mut().pubsub().unsubscribe(topic));
                     }
                     IpfsEvent::PubsubPublish(topic, data, ret) => {
                         self.swarm
                             .behaviour_mut()
-                            .inner
+                            
                             .pubsub()
                             .publish(topic, data);
                         let _ = ret.send(());
@@ -1504,19 +1504,19 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let _ = ret.send(
                             self.swarm
                                 .behaviour_mut()
-                                .inner
+                                
                                 .pubsub()
                                 .subscribed_peers(&topic),
                         );
                     }
                     IpfsEvent::PubsubPeers(None, ret) => {
-                        let _ = ret.send(self.swarm.behaviour_mut().inner.pubsub().known_peers());
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().known_peers());
                     }
                     IpfsEvent::PubsubSubscribed(ret) => {
                         let _ = ret.send(
                             self.swarm
                                 .behaviour_mut()
-                                .inner
+                                
                                 .pubsub()
                                 .subscribed_topics(),
                         );
@@ -1525,19 +1525,19 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let list = if let Some(peer) = peer {
                             self.swarm
                                 .behaviour_mut()
-                                .inner
+                                
                                 .bitswap()
                                 .peer_wantlist(&peer)
                                 .unwrap_or_default()
                         } else {
-                            self.swarm.behaviour_mut().inner.bitswap().local_wantlist()
+                            self.swarm.behaviour_mut().bitswap().local_wantlist()
                         };
                         let _ = ret.send(list);
                     }
                     IpfsEvent::BitswapStats(ret) => {
-                        let stats = self.swarm.behaviour_mut().inner.bitswap().stats();
-                        let peers = self.swarm.behaviour_mut().inner.bitswap().peers();
-                        let wantlist = self.swarm.behaviour_mut().inner.bitswap().local_wantlist();
+                        let stats = self.swarm.behaviour_mut().bitswap().stats();
+                        let peers = self.swarm.behaviour_mut().bitswap().peers();
+                        let wantlist = self.swarm.behaviour_mut().bitswap().local_wantlist();
                         let _ = ret.send((stats, peers, wantlist).into());
                     }
                     IpfsEvent::AddListeningAddress(addr, ret) => {
@@ -1559,21 +1559,21 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let _ = ret.send(removed);
                     }
                     IpfsEvent::Bootstrap(ret) => {
-                        let future = self.swarm.behaviour_mut().inner.bootstrap();
+                        let future = self.swarm.behaviour_mut().bootstrap();
                         let _ = ret.send(future);
                     }
                     IpfsEvent::AddPeer(peer_id, addr) => {
-                        self.swarm.behaviour_mut().inner.add_peer(peer_id, addr);
+                        self.swarm.behaviour_mut().add_peer(peer_id, addr);
                     }
                     IpfsEvent::GetClosestPeers(peer_id, ret) => {
-                        let future = self.swarm.behaviour_mut().inner.get_closest_peers(peer_id);
+                        let future = self.swarm.behaviour_mut().get_closest_peers(peer_id);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::GetBitswapPeers(ret) => {
                         let peers = self
                             .swarm
                             .behaviour_mut()
-                            .inner
+                            
                             .bitswap()
                             .connected_peers
                             .keys()
@@ -1585,7 +1585,7 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let swarm_addrs = self
                             .swarm
                             .behaviour_mut()
-                            .inner
+                            
                             .swarm
                             .connections_to(&peer_id);
                         let locally_known_addrs = if !swarm_addrs.is_empty() {
@@ -1593,7 +1593,7 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         } else {
                             self.swarm
                                 .behaviour_mut()
-                                .inner
+                                
                                 .kademlia()
                                 .addresses_of_peer(&peer_id)
                         };
@@ -1601,44 +1601,44 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                             Either::Left(locally_known_addrs)
                         } else {
                             Either::Right(
-                                self.swarm.behaviour_mut().inner.get_closest_peers(peer_id),
+                                self.swarm.behaviour_mut().get_closest_peers(peer_id),
                             )
                         };
                         let _ = ret.send(addrs);
                     }
                     IpfsEvent::GetProviders(cid, ret) => {
-                        let future = self.swarm.behaviour_mut().inner.get_providers(cid);
+                        let future = self.swarm.behaviour_mut().get_providers(cid);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::Provide(cid, ret) => {
-                        let _ = ret.send(self.swarm.behaviour_mut().inner.start_providing(cid));
+                        let _ = ret.send(self.swarm.behaviour_mut().start_providing(cid));
                     }
                     IpfsEvent::DhtGet(key, quorum, ret) => {
-                        let future = self.swarm.behaviour_mut().inner.dht_get(key, quorum);
+                        let future = self.swarm.behaviour_mut().dht_get(key, quorum);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::DhtPut(key, value, quorum, ret) => {
-                        let future = self.swarm.behaviour_mut().inner.dht_put(key, value, quorum);
+                        let future = self.swarm.behaviour_mut().dht_put(key, value, quorum);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::GetBootstrappers(ret) => {
-                        let list = self.swarm.behaviour_mut().inner.get_bootstrappers();
+                        let list = self.swarm.behaviour_mut().get_bootstrappers();
                         let _ = ret.send(list);
                     }
                     IpfsEvent::AddBootstrapper(addr, ret) => {
-                        let result = self.swarm.behaviour_mut().inner.add_bootstrapper(addr);
+                        let result = self.swarm.behaviour_mut().add_bootstrapper(addr);
                         let _ = ret.send(result);
                     }
                     IpfsEvent::RemoveBootstrapper(addr, ret) => {
-                        let result = self.swarm.behaviour_mut().inner.remove_bootstrapper(addr);
+                        let result = self.swarm.behaviour_mut().remove_bootstrapper(addr);
                         let _ = ret.send(result);
                     }
                     IpfsEvent::ClearBootstrappers(ret) => {
-                        let list = self.swarm.behaviour_mut().inner.clear_bootstrappers();
+                        let list = self.swarm.behaviour_mut().clear_bootstrappers();
                         let _ = ret.send(list);
                     }
                     IpfsEvent::RestoreBootstrappers(ret) => {
-                        let list = self.swarm.behaviour_mut().inner.restore_bootstrappers();
+                        let list = self.swarm.behaviour_mut().restore_bootstrappers();
                         let _ = ret.send(list);
                     }
                     IpfsEvent::Exit => {
@@ -1652,11 +1652,11 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
             // wants this to be written with a `while let`.
             while let Poll::Ready(Some(evt)) = Pin::new(&mut self.repo_events).poll_next(ctx) {
                 match evt {
-                    RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().inner.want_block(cid),
+                    RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().want_block(cid),
                     RepoEvent::UnwantBlock(cid) => self
                         .swarm
                         .behaviour_mut()
-                        .inner
+                        
                         .bitswap()
                         .cancel_block(&cid),
                     RepoEvent::NewBlock(cid, ret) => {
@@ -1664,19 +1664,19 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         // associated Block ourselves
                         self.swarm
                             .behaviour_mut()
-                            .inner
+                            
                             .bitswap()
                             .cancel_block(&cid);
                         // currently disabled; see https://github.com/rs-ipfs/rust-ipfs/pull/281#discussion_r465583345
                         // for details regarding the concerns about enabling this functionality as-is
                         if false {
-                            let _ = ret.send(self.swarm.behaviour_mut().inner.start_providing(cid));
+                            let _ = ret.send(self.swarm.behaviour_mut().start_providing(cid));
                         } else {
                             let _ = ret.send(Err(anyhow!("not actively providing blocks yet")));
                         }
                     }
                     RepoEvent::RemovedBlock(cid) => {
-                        self.swarm.behaviour_mut().inner.stop_providing_block(&cid)
+                        self.swarm.behaviour_mut().stop_providing_block(&cid)
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,8 @@ use futures::{
     sink::SinkExt,
     stream::{Fuse, Stream},
 };
-use libp2p::swarm::NetworkBehaviour;
+use libp2p::{relay::Relay, swarm::NetworkBehaviour};
+use p2p::transport::{default_transport, TTransport};
 use tracing::Span;
 use tracing_futures::Instrument;
 
@@ -193,8 +194,11 @@ impl IpfsOptions {
         }
     }
 
-    pub fn create_uninitialised_ipfs<Types: IpfsTypes>(self) -> UninitializedIpfs<Types> {
-        UninitializedIpfs::new(self)
+    pub fn create_uninitialised_ipfs<Types: IpfsTypes>(
+        self,
+    ) -> std::io::Result<UninitializedIpfs<Types>> {
+        let transport = default_transport(self.keypair.clone())?;
+        Ok(UninitializedIpfs::new(self, transport, None))
     }
 }
 
@@ -320,6 +324,7 @@ pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<
     options: IpfsOptions,
     repo: Arc<Repo<Types>>,
     repo_events: Receiver<RepoEvent>,
+    transport: TTransport,
 }
 
 /// The default builder for Ipfs<Types> without any custom NetworkBehaviours.
@@ -332,7 +337,7 @@ impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
     /// The span is attached to all operations called on the later created `Ipfs` along with all
     /// operations done in the background task as well as tasks spawned by the underlying
     /// `libp2p::Swarm`.
-    pub fn new(options: IpfsOptions) -> Self {
+    pub fn new(options: IpfsOptions, transport: TTransport, relay: Option<Relay>) -> Self {
         let repo_options = RepoOptions::from(&options);
         let (repo, repo_events) = create_repo(repo_options);
         let keys = options.keypair.clone();
@@ -342,12 +347,13 @@ impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
         let channel = channel::<IpfsEvent>(1);
 
         Self {
-            behaviour: p2p::Behaviour::new(swarm_options, arc_repo.clone()),
+            behaviour: p2p::Behaviour::new(swarm_options, arc_repo.clone(), relay),
             ipfs_event_channel: channel,
             keys,
             options: options,
             repo: arc_repo,
             repo_events,
+            transport,
         }
     }
 }
@@ -370,6 +376,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
             options: self.options,
             repo: self.repo,
             repo_events: self.repo_events,
+            transport: self.transport,
         }
     }
 
@@ -394,6 +401,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
             options: self.options,
             repo: self.repo,
             repo_events: self.repo_events,
+            transport: self.transport,
         }
     }
 
@@ -413,6 +421,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
             mut options,
             repo,
             repo_events,
+            transport,
         } = self;
 
         let root_span = options
@@ -446,7 +455,8 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         // FIXME: mutating options above is an unfortunate side-effect of this call, which could be
         // reordered for less error prone code.
         let swarm_options = SwarmOptions::from(&options);
-        let swarm = init_span.in_scope(|| create_swarm(swarm_options, exec_span, behaviour))?;
+        let swarm =
+            init_span.in_scope(|| create_swarm(swarm_options, exec_span, behaviour, transport));
 
         let IpfsOptions {
             listening_addrs, ..
@@ -1756,7 +1766,7 @@ mod node {
             // given span
 
             let (ipfs, fut): (Ipfs<TestTypes>, _) =
-                UninitializedIpfs::new(opts).start().await.unwrap();
+                opts.create_uninitialised_ipfs().unwrap().start().await.unwrap();
             let bg_task = tokio::task::spawn(fut);
             let addrs = ipfs.identity().await.unwrap().1;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,15 @@ enum IpfsEvent {
     Exit,
 }
 
+pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
+    behaviour: p2p::Behaviour<Types, Custom>,
+    ipfs_event_channel: (Sender<IpfsEvent>, Receiver<IpfsEvent>),
+    keys: Keypair,
+    options: IpfsOptions,
+    repo: Arc<Repo<Types>>,
+    repo_events: Receiver<RepoEvent>,
+}
+
 pub type UninitializedIpfs<Types> = UninitializedExtendedIpfs<Types, p2p::NoopBehaviour>;
 
 impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
@@ -327,36 +336,17 @@ impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
         let arc_repo = Arc::new(repo);
         let swarm_options = SwarmOptions::from(&options);
 
-        let (to_task, receiver) = channel::<IpfsEvent>(1);
-
-        // stored in the Ipfs, instrumenting every method call
-        let facade_span = tracing::trace_span!("facade");
-
-        let ipfs = Ipfs {
-            span: facade_span,
-            repo: arc_repo.clone(),
-            keys: DebuggableKeypair(keys),
-            to_task,
-        };
+        let channel = channel::<IpfsEvent>(1);
 
         Self {
-            repo: arc_repo.clone(),
-            ipfs,
-            receiver,
-            repo_events,
             behaviour: p2p::Behaviour::new(swarm_options, arc_repo),
+            ipfs_event_channel: channel,
+            keys,
             options: options,
+            repo: arc_repo.clone(),
+            repo_events,
         }
     }
-}
-
-pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
-    repo: Arc<Repo<Types>>,
-    ipfs: Ipfs<Types>,
-    receiver: Receiver<IpfsEvent>,
-    repo_events: Receiver<RepoEvent>,
-    behaviour: p2p::Behaviour<Types, Custom>,
-    options: IpfsOptions,
 }
 
 impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
@@ -367,12 +357,12 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         behaviour: Custom,
     ) -> UninitializedExtendedIpfs<Types, Custom> {
         UninitializedExtendedIpfs {
-            repo: self.repo,
-            ipfs: self.ipfs,
-            receiver: self.receiver,
-            repo_events: self.repo_events,
-            options: self.options,
             behaviour: self.behaviour.new_custom_behaviour(behaviour),
+            ipfs_event_channel: self.ipfs_event_channel,
+            keys: self.keys,
+            options: self.options,
+            repo: self.repo,
+            repo_events: self.repo_events,
         }
     }
 
@@ -384,14 +374,14 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         Custom: NetworkBehaviour<OutEvent = ()>,
         CustomBuilder: CustomBehaviourBuilder<Types, Custom>,
     {
-        let custom = behaviour_builder.build(self.ipfs.clone());
+        let custom = behaviour_builder.build(self.ipfs_event_channel.0.clone());
         UninitializedExtendedIpfs {
-            repo: self.repo,
-            ipfs: self.ipfs,
-            receiver: self.receiver,
-            repo_events: self.repo_events,
-            options: self.options,
             behaviour: self.behaviour.new_custom_behaviour(custom),
+            ipfs_event_channel: self.ipfs_event_channel,
+            keys: self.keys,
+            options: self.options,
+            repo: self.repo,
+            repo_events: self.repo_events,
         }
     }
     /// Initialize the ipfs node. The returned `Ipfs` value is cloneable, send and sync, and the
@@ -404,12 +394,12 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         use futures::stream::StreamExt;
 
         let Self {
+            behaviour,
+            ipfs_event_channel,
+            keys,
+            mut options,
             repo,
             repo_events,
-            mut options,
-            ipfs,
-            receiver,
-            behaviour,
         } = self;
 
         let root_span = options
@@ -428,7 +418,17 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         // instruments the IpfsFuture, the background task.
         let swarm_span = tracing::trace_span!(parent: &root_span, "swarm");
 
+        // stored in the Ipfs, instrumenting every method call
+        let facade_span = tracing::trace_span!("facade");
+
         repo.init().instrument(init_span.clone()).await?;
+
+        let ipfs = Ipfs {
+            span: facade_span,
+            repo,
+            keys: DebuggableKeypair(keys),
+            to_task: ipfs_event_channel.0,
+        };
 
         // FIXME: mutating options above is an unfortunate side-effect of this call, which could be
         // reordered for less error prone code.
@@ -442,7 +442,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
 
         let mut fut: IpfsFuture<Types, Behaviour> = IpfsFuture {
             repo_events: repo_events.fuse(),
-            from_facade: receiver.fuse(),
+            from_facade: ipfs_event_channel.1.fuse(),
             swarm,
             listening_addresses: HashMap::with_capacity(listening_addrs.len()),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,10 @@ impl IpfsOptions {
             span: None,
         }
     }
+
+    pub fn create_uninitialised_ipfs<Types: IpfsTypes>(self) -> UninitializedIpfs<Types> {
+        UninitializedIpfs::new(self)
+    }
 }
 
 /// Workaround for libp2p::identity::Keypair missing a Debug impl, works with references and owned
@@ -253,7 +257,7 @@ type Channel<T> = OneshotSender<Result<T, Error>>;
 /// Events used internally to communicate with the swarm, which is executed in the the background
 /// task.
 #[derive(Debug)]
-enum IpfsEvent {
+pub enum IpfsEvent {
     /// Connect
     Connect(
         MultiaddrWithPeerId,
@@ -311,6 +315,9 @@ enum IpfsEvent {
     Exit,
 }
 
+/// The general representation of the builder for Ipfs<Types>.
+/// 
+/// For the default representation without any custom NetworkBehaviours, see [UninitializedIpfs](`crate::UninitializedIpfs`).
 pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     behaviour: p2p::Behaviour<Types, Custom>,
     ipfs_event_channel: (Sender<IpfsEvent>, Receiver<IpfsEvent>),
@@ -320,6 +327,7 @@ pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<
     repo_events: Receiver<RepoEvent>,
 }
 
+/// The default builder for Ipfs<Types> without any custom NetworkBehaviours.
 pub type UninitializedIpfs<Types> = UninitializedExtendedIpfs<Types, p2p::NoopBehaviour>;
 
 impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
@@ -339,11 +347,11 @@ impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
         let channel = channel::<IpfsEvent>(1);
 
         Self {
-            behaviour: p2p::Behaviour::new(swarm_options, arc_repo),
+            behaviour: p2p::Behaviour::new(swarm_options, arc_repo.clone()),
             ipfs_event_channel: channel,
             keys,
             options: options,
-            repo: arc_repo.clone(),
+            repo: arc_repo,
             repo_events,
         }
     }
@@ -352,6 +360,10 @@ impl<Types: IpfsTypes> UninitializedExtendedIpfs<Types, p2p::NoopBehaviour> {
 impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
     UninitializedExtendedIpfs<Types, Behaviour>
 {
+    /// Set a custom [NetworkBehaviour](`libp2p::swarm::NetworkBehaviour`) for the Ipfs swarm.
+    /// 
+    /// Custom behaviours must have an [OutEvent](`libp2p::swarm::NetworkBehaviour::OutEvent`)
+    /// of `()`.
     pub fn with_extended_behaviour<Custom: NetworkBehaviour<OutEvent = ()>>(
         self,
         behaviour: Custom,
@@ -366,6 +378,11 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         }
     }
 
+    /// Set a custom [NetworkBehaviour](`libp2p::swarm::NetworkBehaviour`) for the Ipfs swarm from
+    /// a [CustomBehaviourBuilder](`crate::p2p::CustomBehaviourBuilder`).
+    /// 
+    /// Custom behaviours must have an [OutEvent](`libp2p::swarm::NetworkBehaviour::OutEvent`)
+    /// of `()`.
     pub fn with_extended_behaviour_from_builder<Custom, CustomBuilder>(
         self,
         behaviour_builder: CustomBuilder,
@@ -384,11 +401,12 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
             repo_events: self.repo_events,
         }
     }
+
     /// Initialize the ipfs node. The returned `Ipfs` value is cloneable, send and sync, and the
     /// future should be spawned on an executor as soon as possible.
     ///
     /// The future returned from this method should not need
-    /// (instrumenting)[`tracing_futures::Instrument::instrument`] as the [`IpfsOptions::span`]
+    /// [instrumenting](`tracing_futures::Instrument::instrument`) as the [`IpfsOptions::span`]
     /// will be used as parent span for all of the awaited and created futures.
     pub async fn start(self) -> Result<(Ipfs<Types>, impl Future<Output = ()>), Error> {
         use futures::stream::StreamExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ use futures::{
     stream::{Fuse, Stream},
 };
 use libp2p::swarm::NetworkBehaviour;
-use p2p::{CustomBehaviourBuilder, TCustomSwarm};
 use tracing::Span;
 use tracing_futures::Instrument;
 
@@ -71,7 +70,7 @@ use self::{
     ipns::Ipns,
     p2p::{
         addr::{could_be_bound_from_ephemeral, starts_unspecified},
-        create_swarm, SwarmOptions,
+        create_swarm, CustomBehaviourBuilder, SwarmOptions, TCustomSwarm,
     },
     repo::{create_repo, Repo, RepoEvent, RepoOptions},
     subscription::SubscriptionFuture,
@@ -316,7 +315,7 @@ pub enum IpfsEvent {
 }
 
 /// The general representation of the builder for Ipfs<Types>.
-/// 
+///
 /// For the default representation without any custom NetworkBehaviours, see [UninitializedIpfs](`crate::UninitializedIpfs`).
 pub struct UninitializedExtendedIpfs<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     behaviour: p2p::Behaviour<Types, Custom>,
@@ -361,7 +360,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
     UninitializedExtendedIpfs<Types, Behaviour>
 {
     /// Set a custom [NetworkBehaviour](`libp2p::swarm::NetworkBehaviour`) for the Ipfs swarm.
-    /// 
+    ///
     /// Custom behaviours must have an [OutEvent](`libp2p::swarm::NetworkBehaviour::OutEvent`)
     /// of `()`.
     pub fn with_extended_behaviour<Custom: NetworkBehaviour<OutEvent = ()>>(
@@ -380,7 +379,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
 
     /// Set a custom [NetworkBehaviour](`libp2p::swarm::NetworkBehaviour`) for the Ipfs swarm from
     /// a [CustomBehaviourBuilder](`crate::p2p::CustomBehaviourBuilder`).
-    /// 
+    ///
     /// Custom behaviours must have an [OutEvent](`libp2p::swarm::NetworkBehaviour::OutEvent`)
     /// of `()`.
     pub fn with_extended_behaviour_from_builder<Custom, CustomBuilder>(
@@ -429,15 +428,15 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         // the "current" span which is not entered but the awaited futures are instrumented with it
         let init_span = tracing::trace_span!(parent: &root_span, "init");
 
+        // stored in the Ipfs, instrumenting every method call
+        let facade_span = tracing::trace_span!("facade");
+
         // stored in the executor given to libp2p, used to spawn at least the connections,
         // instrumenting each of those.
         let exec_span = tracing::trace_span!(parent: &root_span, "exec");
 
         // instruments the IpfsFuture, the background task.
         let swarm_span = tracing::trace_span!(parent: &root_span, "swarm");
-
-        // stored in the Ipfs, instrumenting every method call
-        let facade_span = tracing::trace_span!("facade");
 
         repo.init().instrument(init_span.clone()).await?;
 
@@ -451,8 +450,7 @@ impl<Types: IpfsTypes, Behaviour: NetworkBehaviour<OutEvent = ()>>
         // FIXME: mutating options above is an unfortunate side-effect of this call, which could be
         // reordered for less error prone code.
         let swarm_options = SwarmOptions::from(&options);
-        let swarm =
-            init_span.in_scope(|| create_swarm(swarm_options, exec_span, behaviour))?;
+        let swarm = init_span.in_scope(|| create_swarm(swarm_options, exec_span, behaviour))?;
 
         let IpfsOptions {
             listening_addrs, ..
@@ -1469,8 +1467,7 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
 
                 match inner {
                     IpfsEvent::Connect(target, ret) => {
-                        ret.send(self.swarm.behaviour_mut().connect(target))
-                            .ok();
+                        ret.send(self.swarm.behaviour_mut().connect(target)).ok();
                     }
                     IpfsEvent::Addresses(ret) => {
                         let addrs = self.swarm.behaviour_mut().addrs();
@@ -1485,9 +1482,7 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         ret.send(Ok(connections.collect())).ok();
                     }
                     IpfsEvent::Disconnect(addr, ret) => {
-                        if let Some(disconnector) =
-                            self.swarm.behaviour_mut().disconnect(addr)
-                        {
+                        if let Some(disconnector) = self.swarm.behaviour_mut().disconnect(addr) {
                             disconnector.disconnect(&mut self.swarm);
                         }
                         ret.send(Ok(())).ok();
@@ -1502,48 +1497,30 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let _ = ret.send(addresses);
                     }
                     IpfsEvent::PubsubSubscribe(topic, ret) => {
-                        let _ =
-                            ret.send(self.swarm.behaviour_mut().pubsub().subscribe(topic));
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().subscribe(topic));
                     }
                     IpfsEvent::PubsubUnsubscribe(topic, ret) => {
-                        let _ =
-                            ret.send(self.swarm.behaviour_mut().pubsub().unsubscribe(topic));
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().unsubscribe(topic));
                     }
                     IpfsEvent::PubsubPublish(topic, data, ret) => {
-                        self.swarm
-                            .behaviour_mut()
-                            
-                            .pubsub()
-                            .publish(topic, data);
+                        self.swarm.behaviour_mut().pubsub().publish(topic, data);
                         let _ = ret.send(());
                     }
                     IpfsEvent::PubsubPeers(Some(topic), ret) => {
                         let topic = libp2p::floodsub::Topic::new(topic);
-                        let _ = ret.send(
-                            self.swarm
-                                .behaviour_mut()
-                                
-                                .pubsub()
-                                .subscribed_peers(&topic),
-                        );
+                        let _ =
+                            ret.send(self.swarm.behaviour_mut().pubsub().subscribed_peers(&topic));
                     }
                     IpfsEvent::PubsubPeers(None, ret) => {
                         let _ = ret.send(self.swarm.behaviour_mut().pubsub().known_peers());
                     }
                     IpfsEvent::PubsubSubscribed(ret) => {
-                        let _ = ret.send(
-                            self.swarm
-                                .behaviour_mut()
-                                
-                                .pubsub()
-                                .subscribed_topics(),
-                        );
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().subscribed_topics());
                     }
                     IpfsEvent::WantList(peer, ret) => {
                         let list = if let Some(peer) = peer {
                             self.swarm
                                 .behaviour_mut()
-                                
                                 .bitswap()
                                 .peer_wantlist(&peer)
                                 .unwrap_or_default()
@@ -1591,7 +1568,6 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let peers = self
                             .swarm
                             .behaviour_mut()
-                            
                             .bitswap()
                             .connected_peers
                             .keys()
@@ -1600,27 +1576,19 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
                         let _ = ret.send(peers);
                     }
                     IpfsEvent::FindPeer(peer_id, local_only, ret) => {
-                        let swarm_addrs = self
-                            .swarm
-                            .behaviour_mut()
-                            
-                            .swarm
-                            .connections_to(&peer_id);
+                        let swarm_addrs = self.swarm.behaviour_mut().swarm.connections_to(&peer_id);
                         let locally_known_addrs = if !swarm_addrs.is_empty() {
                             swarm_addrs
                         } else {
                             self.swarm
                                 .behaviour_mut()
-                                
                                 .kademlia()
                                 .addresses_of_peer(&peer_id)
                         };
                         let addrs = if !locally_known_addrs.is_empty() || local_only {
                             Either::Left(locally_known_addrs)
                         } else {
-                            Either::Right(
-                                self.swarm.behaviour_mut().get_closest_peers(peer_id),
-                            )
+                            Either::Right(self.swarm.behaviour_mut().get_closest_peers(peer_id))
                         };
                         let _ = ret.send(addrs);
                     }
@@ -1671,20 +1639,13 @@ impl<TRepoTypes: RepoTypes, Behaviour: NetworkBehaviour<OutEvent = ()>> Future
             while let Poll::Ready(Some(evt)) = Pin::new(&mut self.repo_events).poll_next(ctx) {
                 match evt {
                     RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().want_block(cid),
-                    RepoEvent::UnwantBlock(cid) => self
-                        .swarm
-                        .behaviour_mut()
-                        
-                        .bitswap()
-                        .cancel_block(&cid),
+                    RepoEvent::UnwantBlock(cid) => {
+                        self.swarm.behaviour_mut().bitswap().cancel_block(&cid)
+                    }
                     RepoEvent::NewBlock(cid, ret) => {
                         // TODO: consider if cancel is applicable in cases where we provide the
                         // associated Block ourselves
-                        self.swarm
-                            .behaviour_mut()
-                            
-                            .bitswap()
-                            .cancel_block(&cid);
+                        self.swarm.behaviour_mut().bitswap().cancel_block(&cid);
                         // currently disabled; see https://github.com/rs-ipfs/rust-ipfs/pull/281#discussion_r465583345
                         // for details regarding the concerns about enabling this functionality as-is
                         if false {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -17,9 +17,9 @@ use libp2p::kad::{Kademlia, KademliaConfig, KademliaEvent, Quorum};
 use libp2p::relay::Relay;
 // use libp2p::mdns::{MdnsEvent, TokioMdns};
 use libp2p::ping::{Ping, PingEvent};
+use libp2p::swarm::toggle::Toggle;
 // use libp2p::swarm::toggle::Toggle;
 use libp2p::swarm::{DummyBehaviour, NetworkBehaviour, NetworkBehaviourEventProcess};
-use multibase::Base;
 use std::{convert::TryInto, sync::Arc};
 use tokio::task;
 
@@ -57,7 +57,7 @@ pub struct Behaviour<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> 
     ping: Ping,
     identify: Identify,
     pubsub: Pubsub,
-    relay: Relay,
+    relay: Toggle<Relay>,
     pub swarm: SwarmApi,
     custom: Custom,
 }
@@ -459,7 +459,7 @@ impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>>
 
 impl<Types: IpfsTypes> Behaviour<Types, NoopBehaviour> {
     /// Create a Kademlia behaviour with the IPFS bootstrap nodes.
-    pub fn new(options: SwarmOptions, repo: Arc<Repo<Types>>, relay: Relay) -> Self {
+    pub fn new(options: SwarmOptions, repo: Arc<Repo<Types>>, relay: Option<Relay>) -> Self {
         info!("net: starting with peer id {}", options.peer_id);
 
         /*
@@ -510,7 +510,7 @@ impl<Types: IpfsTypes> Behaviour<Types, NoopBehaviour> {
             identify,
             pubsub,
             swarm,
-            relay,
+            relay: relay.into(),
             custom: NoopBehaviour::default(),
         }
     }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -22,6 +22,10 @@ use multibase::Base;
 use std::{convert::TryInto, sync::Arc};
 use tokio::task;
 
+/// A "do-nothing" behaviour.
+/// 
+/// This is the default "custom" behaviour for Ipfs. This is replaced by supplying a custom
+/// behaviour to the [UninitializedIpfs](`crate::UninitializedIpfs`).
 #[derive(Clone, Default, NetworkBehaviour)]
 pub struct NoopBehaviour {
     inner: DummyBehaviour
@@ -31,6 +35,7 @@ impl NetworkBehaviourEventProcess<void::Void> for NoopBehaviour {
     fn inject_event(&mut self, _event: void::Void) {}
 }
 
+/// Enables the building of custom NetworkBehaviours which need access to the Ipfs interface.
 pub trait CustomBehaviourBuilder<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     /// Build method for your NetworkBehaviour implementation if your behaviour needs access to IPFS at runtime.
     /// 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -21,28 +21,6 @@ use multibase::Base;
 use std::{convert::TryInto, sync::Arc};
 use tokio::task;
 
-#[derive(libp2p::NetworkBehaviour)]
-pub struct ExtendedBehaviour<Types: IpfsTypes, Ext: NetworkBehaviour> {
-    pub(crate) inner: Behaviour<Types>,
-    custom: Ext,
-}
-
-impl<Types: IpfsTypes, Ext: NetworkBehaviour> NetworkBehaviourEventProcess<()> for ExtendedBehaviour<Types, Ext> {
-    fn inject_event(&mut self, _event: ()) {}
-}
-impl<Types: IpfsTypes, Ext: NetworkBehaviour> NetworkBehaviourEventProcess<void::Void> for ExtendedBehaviour<Types, Ext> {
-    fn inject_event(&mut self, _event: void::Void) {}
-}
-
-impl<Types: IpfsTypes, Ext: NetworkBehaviour> ExtendedBehaviour<Types, Ext> {
-    pub(crate) fn new_extended_behaviour<NExt: NetworkBehaviour>(self, new: NExt) -> ExtendedBehaviour<Types, NExt> {
-        ExtendedBehaviour {
-            inner: self.inner,
-            custom: new,
-        }
-    }
-}
-
 #[derive(Clone, Default, NetworkBehaviour)]
 pub struct NoopBehaviour {
     inner: DummyBehaviour
@@ -52,25 +30,16 @@ impl NetworkBehaviourEventProcess<void::Void> for NoopBehaviour {
     fn inject_event(&mut self, _event: void::Void) {}
 }
 
-pub trait ExtendedBehaviourBuilder<Types: IpfsTypes, Ext: NetworkBehaviour> {
+pub trait CustomBehaviourBuilder<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     /// Build method for your NetworkBehaviour implementation if your behaviour needs access to IPFS at runtime.
     /// 
     /// The IPFS object will be uninitialised until started with ExtendedUninitialisedIpfs::start
-    fn build(self, ipfs: Ipfs<Types>) -> Ext;
-}
-
-impl<Types: IpfsTypes> ExtendedBehaviour<Types, NoopBehaviour> {
-    pub fn new(options: SwarmOptions, repo: Arc<Repo<Types>>) -> Self {
-        Self {
-            inner: Behaviour::new(options, repo),
-            custom: NoopBehaviour::default(),
-        }
-    }
+    fn build(self, ipfs: Ipfs<Types>) -> Custom;
 }
 
 /// Behaviour type.
 #[derive(libp2p::NetworkBehaviour)]
-pub struct Behaviour<Types: IpfsTypes> {
+pub struct Behaviour<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     #[behaviour(ignore)]
     repo: Arc<Repo<Types>>,
     // mdns: Toggle<TokioMdns>,
@@ -82,6 +51,7 @@ pub struct Behaviour<Types: IpfsTypes> {
     identify: Identify,
     pubsub: Pubsub,
     pub swarm: SwarmApi,
+    custom: Custom,
 }
 
 /// Represents the result of a Kademlia query.
@@ -95,10 +65,10 @@ pub enum KadResult {
     Records(Vec<Record>),
 }
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<()> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<()> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, _event: ()) {}
 }
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<void::Void> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<void::Void> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, _event: void::Void) {}
 }
 
@@ -123,7 +93,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<MdnsEvent> for Behaviour<Typ
 }
 */
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, event: KademliaEvent) {
         use libp2p::kad::{
             AddProviderError, AddProviderOk, BootstrapError, BootstrapOk, GetClosestPeersError,
@@ -367,7 +337,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
     }
 }
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, event: BitswapEvent) {
         match event {
             BitswapEvent::ReceivedBlock(peer_id, block) => {
@@ -423,7 +393,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<
     }
 }
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<PingEvent> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<PingEvent> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, event: PingEvent) {
         use libp2p::ping::handler::{PingFailure, PingSuccess};
         match event {
@@ -461,13 +431,13 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<PingEvent> for Behaviour<Typ
     }
 }
 
-impl<Types: IpfsTypes> NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour<Types> {
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour<Types, Custom> {
     fn inject_event(&mut self, event: IdentifyEvent) {
         trace!("identify: {:?}", event);
     }
 }
 
-impl<Types: IpfsTypes> Behaviour<Types> {
+impl<Types: IpfsTypes> Behaviour<Types, NoopBehaviour> {
     /// Create a Kademlia behaviour with the IPFS bootstrap nodes.
     pub fn new(options: SwarmOptions, repo: Arc<Repo<Types>>) -> Self {
         info!("net: starting with peer id {}", options.peer_id);
@@ -520,6 +490,23 @@ impl<Types: IpfsTypes> Behaviour<Types> {
             identify,
             pubsub,
             swarm,
+            custom:  NoopBehaviour::default(),
+        }
+    }
+}
+
+impl<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> Behaviour<Types, Custom> {
+    pub(crate) fn new_custom_behaviour<New: NetworkBehaviour<OutEvent = ()>>(self, new: New) -> Behaviour<Types, New> {
+        Behaviour {
+            repo: self.repo,
+            kademlia: self.kademlia,
+            kad_subscriptions: self.kad_subscriptions,
+            bitswap: self.bitswap,
+            ping: self.ping,
+            identify: self.identify,
+            pubsub: self.pubsub,
+            swarm: self.swarm,
+            custom: new,
         }
     }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -4,9 +4,10 @@ use crate::config::BOOTSTRAP_NODES;
 use crate::p2p::{MultiaddrWithPeerId, SwarmOptions};
 use crate::repo::{BlockPut, Repo};
 use crate::subscription::{SubscriptionFuture, SubscriptionRegistry};
-use crate::{IpfsTypes, Ipfs};
+use crate::{IpfsTypes, IpfsEvent};
 use anyhow::anyhow;
 use cid::Cid;
+use futures::channel::mpsc::Sender;
 use ipfs_bitswap::{Bitswap, BitswapEvent};
 use libp2p::NetworkBehaviour;
 use libp2p::core::{Multiaddr, PeerId};
@@ -33,8 +34,8 @@ impl NetworkBehaviourEventProcess<void::Void> for NoopBehaviour {
 pub trait CustomBehaviourBuilder<Types: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>> {
     /// Build method for your NetworkBehaviour implementation if your behaviour needs access to IPFS at runtime.
     /// 
-    /// The IPFS object will be uninitialised until started with ExtendedUninitialisedIpfs::start
-    fn build(self, ipfs: Ipfs<Types>) -> Custom;
+    /// Building a NetworkBehaviour implementation with this function will give it access to push events onto the IPFS event channel.
+    fn build(self, ipfs_event_sink: Sender<IpfsEvent>) -> Custom;
 }
 
 /// Behaviour type.

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -16,13 +16,13 @@ mod transport;
 pub use addr::{MultiaddrWithPeerId, MultiaddrWithoutPeerId};
 
 pub use {
-    behaviour::{Behaviour, ExtendedBehaviour, ExtendedBehaviourBuilder, KadResult, NoopBehaviour},
+    behaviour::{Behaviour, CustomBehaviourBuilder, KadResult, NoopBehaviour},
     swarm::Connection,
 };
 
 /// Type alias for [`libp2p::Swarm`] running the [`behaviour::Behaviour`] with the given [`IpfsTypes`].
-pub type TSwarm<T> = Swarm<ExtendedBehaviour<T, NoopBehaviour>>;
-pub type TExtendedSwarm<T, Ext> = Swarm<ExtendedBehaviour<T, Ext>>;
+pub type TSwarm<T> = Swarm<Behaviour<T, NoopBehaviour>>;
+pub type TCustomSwarm<T, Custom> = Swarm<Behaviour<T, Custom>>;
 
 /// Defines the configuration for an IPFS swarm.
 pub struct SwarmOptions {
@@ -57,11 +57,11 @@ impl From<&IpfsOptions> for SwarmOptions {
 }
 
 /// Creates a new IPFS swarm.
-pub fn create_swarm<TIpfsTypes: IpfsTypes, Ext: NetworkBehaviour<OutEvent = ()>>(
+pub fn create_swarm<TIpfsTypes: IpfsTypes, Custom: NetworkBehaviour<OutEvent = ()>>(
     options: SwarmOptions,
     span: Span,
-    behaviour: ExtendedBehaviour<TIpfsTypes, Ext>,
-) -> io::Result<TExtendedSwarm<TIpfsTypes, Ext>> {
+    behaviour: Behaviour<TIpfsTypes, Custom>,
+) -> io::Result<TCustomSwarm<TIpfsTypes, Custom>> {
     let peer_id = options.peer_id;
 
     // Set up an encrypted TCP transport over the Mplex protocol.

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -22,6 +22,8 @@ pub use {
 
 /// Type alias for [`libp2p::Swarm`] running the [`behaviour::Behaviour`] with the given [`IpfsTypes`].
 pub type TSwarm<T> = Swarm<Behaviour<T, NoopBehaviour>>;
+/// Type alias for [`libp2p::Swarm`] running the [`behaviour::Behaviour`] with the given [`IpfsTypes`],
+/// and a custom [`libp2p::swarm::NetworkBehaviour`].
 pub type TCustomSwarm<T, Custom> = Swarm<Behaviour<T, Custom>>;
 
 /// Defines the configuration for an IPFS swarm.

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod addr;
 mod behaviour;
 pub(crate) mod pubsub;
 mod swarm;
-mod transport;
+pub mod transport;
 
 pub use addr::{MultiaddrWithPeerId, MultiaddrWithoutPeerId};
 pub use {behaviour::KadResult, swarm::Connection};
@@ -61,7 +61,10 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     let peer_id = options.peer_id;
 
     // Set up an encrypted TCP transport over the Mplex protocol.
-    let transport = transport::build_transport(options.keypair.clone())?;
+    let transport = transport::TransportBuilder::new(options.keypair.clone())?.build_transport();
+    //let upgrader = transport::TransportBuilder::new(options.keypair.clone())?.then();
+    //use crate::apply_upgrades;
+    //let transport = apply_upgrades!(upgrader =>);
 
     // Create a Kademlia behaviour
     let behaviour = behaviour::build_behaviour(options, repo).await;

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -582,7 +582,7 @@ mod tests {
     fn build_swarm() -> (PeerId, libp2p::swarm::Swarm<SwarmApi>) {
         let key = Keypair::generate_ed25519();
         let peer_id = key.public().into_peer_id();
-        let transport = TransportBuilder::new(key).unwrap().build_transport();
+        let transport = TransportBuilder::new(key).unwrap().build();
 
         let swarm = SwarmBuilder::new(transport, SwarmApi::default(), peer_id)
             .executor(Box::new(ThreadLocalTokio))

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -414,7 +414,7 @@ fn connection_point_addr(cp: &ConnectedPoint) -> MultiaddrWithoutPeerId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::p2p::transport::build_transport;
+    use crate::p2p::transport::TransportBuilder;
     use futures::{
         stream::{StreamExt, TryStreamExt},
         TryFutureExt,
@@ -582,7 +582,7 @@ mod tests {
     fn build_swarm() -> (PeerId, libp2p::swarm::Swarm<SwarmApi>) {
         let key = Keypair::generate_ed25519();
         let peer_id = key.public().into_peer_id();
-        let transport = build_transport(key).unwrap();
+        let transport = TransportBuilder::new(key).unwrap().build_transport();
 
         let swarm = SwarmBuilder::new(transport, SwarmApi::default(), peer_id)
             .executor(Box::new(ThreadLocalTokio))

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -21,6 +21,9 @@ use trust_dns_resolver::name_server::{GenericConnection, GenericConnectionProvid
 /// Transport type.
 pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
+pub fn default_transport(keypair: identity::Keypair) -> io::Result<TTransport> {
+    TransportBuilder::new(keypair).map(TransportBuilder::build_transport)
+}
 pub struct TransportBuilder<T: Transport> {
     keypair: identity::Keypair,
     transport: T,

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -44,13 +44,13 @@
 //!     .apply(upgrade)
 //!     .build();
 //! ```
-use futures::{AsyncRead, AsyncWrite, Future};
+use futures::{AsyncRead, AsyncWrite, Future, TryFutureExt};
 use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::and_then::AndThen;
 use libp2p::core::transport::upgrade::{Authenticate, Authenticated, Version};
 use libp2p::core::transport::{Boxed, OrTransport, Upgrade};
 use libp2p::core::upgrade::SelectUpgrade;
-use libp2p::core::{ConnectedPoint, Negotiated};
+use libp2p::core::{ConnectedPoint, Negotiated, UpgradeInfo};
 use libp2p::dns::{GenDnsConfig, TokioDnsConfig};
 use libp2p::mplex::MplexConfig;
 use libp2p::noise::{self, NoiseAuthenticated, NoiseConfig, X25519Spec, XX};
@@ -78,6 +78,7 @@ pub fn default_transport(keypair: identity::Keypair) -> io::Result<TTransport> {
 /// extend the base IPFS transport implementation, then you do not need to use this builder and can
 /// instead construct your [UninitializedIpfs](`crate::UninitializedIpfs`) directly from
 /// [IpfsOptions](`crate::IpfsOptions`).
+#[derive(Clone)]
 pub struct TransportBuilder<T> {
     keypair: identity::Keypair,
     transport: T,
@@ -100,7 +101,6 @@ impl<T> TransportBuilder<T>
 where
     T: Transport + Clone + Send + Sync + 'static,
     T::Dial: Send,
-    T::Error: 'static,
     T::Error: Send + Sync + 'static,
     T::Listener: Send,
     T::ListenerUpgrade: Send,
@@ -125,9 +125,16 @@ where
         )
     }
 
-    pub fn then(
-        self,
-    ) -> TransportUpgrader<
+    pub fn map_auth(self) -> TransportAuthMapper<T, NoiseAuthenticated<XX, X25519Spec, ()>>
+    {
+        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
+            .into_authentic(&self.keypair)
+            .unwrap();
+        let noise_auth = NoiseConfig::xx(xx_keypair).into_authenticated();
+        TransportAuthMapper { transport: self.transport, auth: noise_auth }
+    }
+
+    pub fn apply_upgrades(self) -> TransportUpgrader<
         AndThen<
             T,
             impl Clone
@@ -138,29 +145,83 @@ where
                     -> Authenticate<T::Output, NoiseAuthenticated<XX, X25519Spec, ()>>,
         >,
     > {
-        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
-            .into_authentic(&self.keypair)
-            .unwrap();
-        let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
-        TransportUpgrader {
-            authenticated: self
-                .transport
-                .upgrade(Version::V1)
-                .authenticate(noise_config),
-        }
+        self.map_auth().apply_upgrades()
     }
 
     /// Builds the transport that serves as a common ground for all connections.
     ///
     /// Set up an encrypted TCP transport over the Mplex protocol.
     pub fn build(self) -> TTransport {
-        self.then().build()
+        self.map_auth().apply_upgrades().build()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TransportAuthMapper<T, A> 
+{
+    transport: T,
+    auth: A,
+}
+
+impl<T, A, C, E, F> TransportAuthMapper<T, A> 
+where
+    T: Transport + Clone + Send + Sync + 'static,
+    T::Dial: Send,
+    T::Error: Send + Sync + 'static,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    T::Output: AsyncWrite + AsyncRead + Unpin + Send + 'static,
+    A: Clone + Send + Sync + 'static,
+    A: InboundUpgrade<Negotiated<T::Output>, Output = (PeerId, C), Error = E, Future = F>,
+    A: OutboundUpgrade<Negotiated<T::Output>, Output = (PeerId, C), Error = E, Future = F>,
+    <A as UpgradeInfo>::Info: Send,
+    <<A as UpgradeInfo>::InfoIter as IntoIterator>::IntoIter: Send,
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    E: Send + Sync + StdError + 'static,
+    F: Send + 'static,
+{
+    pub fn map_inbound<Fun>(self, fun: Fun) -> TransportAuthMapper<T, TryMapInboundUpgrade<A, Fun>>
+    where
+    {
+        let auth = TryMapInboundUpgrade{ upgrade: self.auth, fun };
+        TransportAuthMapper{transport: self.transport, auth }
+    } 
+
+    pub fn map_outbound<Fun>(self, fun: Fun) -> TransportAuthMapper<T, TryMapOutboundUpgrade<A, Fun>>
+    where
+    {
+        let auth = TryMapOutboundUpgrade{ upgrade: self.auth, fun };
+        TransportAuthMapper{transport: self.transport, auth }
+    } 
+
+    pub fn apply_upgrades(self) -> TransportUpgrader<
+        AndThen<
+            T,
+            impl Clone
+                + FnOnce(
+                    T::Output,
+                    ConnectedPoint,
+                )
+                    -> Authenticate<T::Output, A>,
+        >,
+    >
+    {
+        TransportUpgrader { authenticated: self.transport.upgrade(Version::V1).authenticate(self.auth) }
+    }
+
+
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
+    pub fn build(self) -> TTransport {
+        self.apply_upgrades().build()
     }
 }
 
 /// Upgrader for IPFS Transports.
 /// 
 /// Facilitates the application of [Upgrades](`Upgrade`) to the transport.
+#[derive(Clone)]
 pub struct TransportUpgrader<T> {
     authenticated: Authenticated<T>,
 }
@@ -187,6 +248,10 @@ where
         TransportUpgrader { authenticated }
     }
 
+
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
     pub fn build(self) -> TTransport {
         self.authenticated
             .multiplex(SelectUpgrade::new(
@@ -197,5 +262,81 @@ where
             .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
             .map_err(|err| Error::new(ErrorKind::Other, err))
             .boxed()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TryMapInboundUpgrade<U, F>
+{
+    upgrade: U,
+    fun: F,
+}
+
+impl<U, F> UpgradeInfo for TryMapInboundUpgrade<U, F>
+where
+  U: UpgradeInfo
+{
+    type Info = U::Info;
+
+    type InfoIter = U::InfoIter;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        self.upgrade.protocol_info()
+    }
+}
+
+impl<U, F, T, Fut, D> InboundUpgrade<T> for TryMapInboundUpgrade<U, F> 
+where
+    U: InboundUpgrade<T>,
+    F: FnOnce(U::Output) -> Fut,
+    Fut: Future<Output = Result<D, U::Error>>,
+  {
+    type Output = D;
+
+    type Error = U::Error;
+
+    type Future = futures::future::AndThen<U::Future, Fut, F>;
+
+
+    fn upgrade_inbound(self, socket: T, info: Self::Info) -> Self::Future {
+        self.upgrade.upgrade_inbound(socket, info).and_then( self.fun )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TryMapOutboundUpgrade<U, F>
+{
+    upgrade: U,
+    fun: F,
+}
+
+impl<U, F> UpgradeInfo for TryMapOutboundUpgrade<U, F>
+where
+  U: UpgradeInfo
+{
+    type Info = U::Info;
+
+    type InfoIter = U::InfoIter;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        self.upgrade.protocol_info()
+    }
+}
+
+impl<U, F, T, Fut, D> OutboundUpgrade<T> for TryMapOutboundUpgrade<U, F> 
+where
+    U: OutboundUpgrade<T>,
+    F: FnOnce(U::Output) -> Fut,
+    Fut: Future<Output = Result<D, U::Error>>,
+  {
+    type Output = D;
+
+    type Error = U::Error;
+
+    type Future = futures::future::AndThen<U::Future, Fut, F>;
+
+
+    fn upgrade_outbound(self, socket: T, info: Self::Info) -> Self::Future {
+        self.upgrade.upgrade_outbound(socket, info).and_then( self.fun )
     }
 }

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -1,12 +1,59 @@
+//! Construction of [Transports](`libp2p::Transport`) for IPFS.
+//! 
+//! This module is only needed if you need to extend the functionality of the underlying
+//! [Transport](`libp2p::Transport`).
+//!
+//! The base IPFS transport can be extended using [`TransportBuilder::or`] to wrap the base
+//! transport implementation inside another (see [`OrTransport`]):
+//!
+//! ```
+//! use ipfs::p2p::transport::{TTransport, TransportBuilder};
+//! use libp2p::core::transport::MemoryTransport;
+//! use libp2p::identity::Keypair;
+//! let keypair: Keypair = Keypair::generate_ed25519();
+//! let transport: TTransport = TransportBuilder::new(keypair).unwrap()
+//!     .or(MemoryTransport::default())
+//!     .build();
+//! ```
+//!
+//! To perform additional [Upgrades](`Upgrade`) on the connection, first apply any Transport
+//! extensions, use [`TransportBuilder::then`] to convert this builder into a [`TransportUpgrader`]
+//! , and then [apply](`TransportUpgrader::apply`) upgrades:
+//! 
+//! ```
+//! use ipfs::p2p::transport::{TTransport, TransportBuilder};
+//! use libp2p::core::upgrade;
+//! use libp2p::identity::Keypair;
+//! use std::io;
+//! let keypair: Keypair = Keypair::generate_ed25519();
+//! let upgrade = upgrade::from_fn("/foo/1", move |mut sock: upgrade::Negotiated<_>, endpoint| async move {
+//!     if endpoint.is_dialer() {
+//!         upgrade::write_length_prefixed(&mut sock, "some handshake data").await?;
+//!         # use futures::AsyncWriteExt;
+//!         sock.close().await?;
+//!     } else {
+//!         let handshake_data = upgrade::read_length_prefixed(&mut sock, 1024).await?;
+//!         if handshake_data != b"some handshake data" {
+//!             return Err(io::Error::new(io::ErrorKind::Other, "bad handshake"));
+//!         }
+//!     }
+//!     Ok(sock)
+//! });
+//! let transport: TTransport = TransportBuilder::new(keypair).unwrap()
+//!     .then()
+//!     .apply(upgrade)
+//!     .build();
+//! ```
 use futures::{AsyncRead, AsyncWrite, Future};
 use libp2p::core::muxing::StreamMuxerBox;
-use libp2p::core::transport::upgrade::{Builder, Version};
-use libp2p::core::transport::{Boxed, OrTransport};
+use libp2p::core::transport::and_then::AndThen;
+use libp2p::core::transport::upgrade::{Authenticate, Authenticated, Version};
+use libp2p::core::transport::{Boxed, OrTransport, Upgrade};
 use libp2p::core::upgrade::SelectUpgrade;
-use libp2p::core::{Negotiated, UpgradeInfo};
+use libp2p::core::{ConnectedPoint, Negotiated};
 use libp2p::dns::{GenDnsConfig, TokioDnsConfig};
 use libp2p::mplex::MplexConfig;
-use libp2p::noise::{self, NoiseAuthenticated, NoiseConfig, NoiseOutput, X25519Spec, XX};
+use libp2p::noise::{self, NoiseAuthenticated, NoiseConfig, X25519Spec, XX};
 use libp2p::relay::{Relay, RelayTransport};
 use libp2p::tcp::tokio::Tcp;
 use libp2p::tcp::{GenTcpConfig, TokioTcpConfig};
@@ -19,12 +66,19 @@ use std::time::Duration;
 use trust_dns_resolver::name_server::{GenericConnection, GenericConnectionProvider, TokioRuntime};
 
 /// Transport type.
-pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
+pub type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
 pub fn default_transport(keypair: identity::Keypair) -> io::Result<TTransport> {
-    TransportBuilder::new(keypair).map(TransportBuilder::build_transport)
+    TransportBuilder::new(keypair).map(TransportBuilder::build)
 }
-pub struct TransportBuilder<T: Transport> {
+
+/// Builder for IPFS Transports.
+///
+/// This type can be used to build IPFS compatible Transport implementations. If you do not need to
+/// extend the base IPFS transport implementation, then you do not need to use this builder and can
+/// instead construct your [UninitializedIpfs](`crate::UninitializedIpfs`) directly from
+/// [IpfsOptions](`crate::IpfsOptions`).
+pub struct TransportBuilder<T> {
     keypair: identity::Keypair,
     transport: T,
 }
@@ -42,9 +96,15 @@ impl
     }
 }
 
-impl<T: Transport> TransportBuilder<T>
+impl<T> TransportBuilder<T>
 where
-    <T as Transport>::Error: 'static,
+    T: Transport + Clone + Send + Sync + 'static,
+    T::Dial: Send,
+    T::Error: 'static,
+    T::Error: Send + Sync + 'static,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    T::Output: AsyncWrite + AsyncRead + Unpin + Send + 'static,
 {
     pub fn or<O: Transport>(self, other: O) -> TransportBuilder<OrTransport<O, T>> {
         TransportBuilder {
@@ -52,9 +112,7 @@ where
             transport: other.or_transport(self.transport),
         }
     }
-}
 
-impl<T: Transport + Clone> TransportBuilder<T> {
     pub fn relay(self) -> (TransportBuilder<RelayTransport<T>>, Relay) {
         let (transport, relay) =
             libp2p::relay::new_transport_and_behaviour(Default::default(), self.transport);
@@ -66,143 +124,78 @@ impl<T: Transport + Clone> TransportBuilder<T> {
             relay,
         )
     }
-}
 
-impl<T: Transport + Clone + Send + Sync + 'static> TransportBuilder<T>
-where
-    <T as Transport>::Error: Send + Sync + 'static,
-    <T as Transport>::Output: AsyncWrite + AsyncRead + Unpin + Send + 'static,
-    <T as Transport>::Listener: Send,
-    <T as Transport>::ListenerUpgrade: Send,
-    <T as Transport>::Dial: Send,
-{
-    /// Builds the transport that serves as a common ground for all connections.
-    ///
-    /// Set up an encrypted TCP transport over the Mplex protocol.
-    pub fn build_transport(self) -> TTransport {
+    pub fn then(
+        self,
+    ) -> TransportUpgrader<
+        AndThen<
+            T,
+            impl Clone
+                + FnOnce(
+                    T::Output,
+                    ConnectedPoint,
+                )
+                    -> Authenticate<T::Output, NoiseAuthenticated<XX, X25519Spec, ()>>,
+        >,
+    > {
         let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
             .into_authentic(&self.keypair)
             .unwrap();
         let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
-        self.transport
-            .upgrade(Version::V1)
-            .authenticate(noise_config)
-            .multiplex(SelectUpgrade::new(
-                YamuxConfig::default(),
-                MplexConfig::new(),
-            ))
-            .timeout(Duration::from_secs(20))
-            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-            .map_err(|err| Error::new(ErrorKind::Other, err))
-            .boxed()
-    }
-
-    /// Builds the transport that serves as a common ground for all connections.
-    ///
-    /// Set up an encrypted TCP transport over the Mplex protocol.
-    pub fn build_transport_with_upgrade<U, D, E, F, I, It>(self, upgrade: U) -> TTransport
-    where
-        D: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-        E: StdError + Send + Sync + 'static,
-        F: Future + Send + Sync,
-        I: IntoIterator<IntoIter = It>,
-        It: Send + Sync + Iterator,
-        <It as Iterator>::Item: Send + Sync,
-        U: Send + Sync + Clone + 'static,
-        U: InboundUpgrade<
-            Negotiated<NoiseOutput<Negotiated<<T as Transport>::Output>>>,
-            Output = D,
-            Error = E,
-            Future = F,
-        >,
-        U: OutboundUpgrade<
-            Negotiated<NoiseOutput<Negotiated<<T as Transport>::Output>>>,
-            Output = D,
-            Error = E,
-            Future = F,
-        >,
-        U: UpgradeInfo<InfoIter = I>,
-        <U as UpgradeInfo>::Info: Send,
-    {
-        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
-            .into_authentic(&self.keypair)
-            .unwrap();
-        let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
-        self.transport
-            .upgrade(Version::V1)
-            .authenticate(noise_config)
-            .apply(upgrade)
-            .multiplex(SelectUpgrade::new(
-                YamuxConfig::default(),
-                MplexConfig::new(),
-            ))
-            .timeout(Duration::from_secs(20))
-            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-            .map_err(|err| Error::new(ErrorKind::Other, err))
-            .boxed()
-    }
-}
-
-pub mod apply_upgrades {
-    use super::{
-        noise, Builder, NoiseAuthenticated, NoiseConfig, TransportBuilder, X25519Spec, XX,
-    };
-
-    pub use std::{
-        io::{Error, ErrorKind},
-        time::Duration,
-    };
-
-    pub use libp2p::{
-        core::{
-            muxing::StreamMuxerBox,
-            upgrade::{SelectUpgrade, Version},
-        },
-        mplex::MplexConfig,
-        yamux::YamuxConfig,
-        Transport,
-    };
-
-    impl<T: Transport> TransportBuilder<T>
-    where
-        <T as Transport>::Error: 'static,
-    {
-        pub fn then(self) -> TransportUpgrader<T> {
-            let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
-                .into_authentic(&self.keypair)
-                .unwrap();
-            let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
-            TransportUpgrader {
-                noise_config,
-                builder: self.transport.upgrade(Version::V1),
-            }
+        TransportUpgrader {
+            authenticated: self
+                .transport
+                .upgrade(Version::V1)
+                .authenticate(noise_config),
         }
     }
 
-    pub struct TransportUpgrader<T: Transport> {
-        pub noise_config: NoiseAuthenticated<XX, X25519Spec, ()>,
-        pub builder: Builder<T>,
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
+    pub fn build(self) -> TTransport {
+        self.then().build()
+    }
+}
+
+/// Upgrader for IPFS Transports.
+/// 
+/// Facilitates the application of [Upgrades](`Upgrade`) to the transport.
+pub struct TransportUpgrader<T> {
+    authenticated: Authenticated<T>,
+}
+
+impl<T, C> TransportUpgrader<T>
+where
+    T: Transport<Output = (PeerId, C)> + Clone + Send + Sync + 'static,
+    T::Dial: Send,
+    T::Error: Send + Sync + 'static,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    pub fn apply<U, D, E, F>(self, u: U) -> TransportUpgrader<Upgrade<T, U>>
+    where
+        U: InboundUpgrade<Negotiated<C>, Output = D, Error = E, Future = F>,
+        U: OutboundUpgrade<Negotiated<C>, Output = D, Error = E, Future = F>,
+        U: Clone,
+        D: AsyncRead + AsyncWrite + Unpin,
+        E: StdError + 'static,
+        F: Future,
+    {
+        let authenticated = self.authenticated.apply(u);
+        TransportUpgrader { authenticated }
     }
 
-    #[macro_export]
-    macro_rules! apply_upgrades {
-        ($upgrader:expr => $($upgrades:expr),*) => {
-            {
-                use $crate::p2p::transport::apply_upgrades::*;
-                $upgrader.builder
-                    .authenticate($upgrader.noise_config)
-                    $(
-                        .apply($upgrades)
-                    )*
-                    .multiplex(SelectUpgrade::new(
-                        YamuxConfig::default(),
-                        MplexConfig::new(),
-                    ))
-                    .timeout(Duration::from_secs(20))
-                    .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-                    .map_err(|err| Error::new(ErrorKind::Other, err))
-                    .boxed()
-            }
-        };
+    pub fn build(self) -> TTransport {
+        self.authenticated
+            .multiplex(SelectUpgrade::new(
+                YamuxConfig::default(),
+                MplexConfig::new(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+            .map_err(|err| Error::new(ErrorKind::Other, err))
+            .boxed()
     }
 }

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -1,38 +1,205 @@
+use futures::{AsyncRead, AsyncWrite, Future};
 use libp2p::core::muxing::StreamMuxerBox;
-use libp2p::core::transport::upgrade::Version;
-use libp2p::core::transport::Boxed;
+use libp2p::core::transport::upgrade::{Builder, Version};
+use libp2p::core::transport::{Boxed, OrTransport};
 use libp2p::core::upgrade::SelectUpgrade;
-use libp2p::dns::TokioDnsConfig;
-use libp2p::identity;
+use libp2p::core::{Negotiated, UpgradeInfo};
+use libp2p::dns::{GenDnsConfig, TokioDnsConfig};
 use libp2p::mplex::MplexConfig;
-use libp2p::noise::{self, NoiseConfig};
-use libp2p::tcp::TokioTcpConfig;
+use libp2p::noise::{self, NoiseAuthenticated, NoiseConfig, NoiseOutput, X25519Spec, XX};
+use libp2p::relay::{Relay, RelayTransport};
+use libp2p::tcp::tokio::Tcp;
+use libp2p::tcp::{GenTcpConfig, TokioTcpConfig};
 use libp2p::yamux::YamuxConfig;
+use libp2p::{identity, InboundUpgrade, OutboundUpgrade};
 use libp2p::{PeerId, Transport};
+use std::error::Error as StdError;
 use std::io::{self, Error, ErrorKind};
 use std::time::Duration;
+use trust_dns_resolver::name_server::{GenericConnection, GenericConnectionProvider, TokioRuntime};
 
 /// Transport type.
 pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
-/// Builds the transport that serves as a common ground for all connections.
-///
-/// Set up an encrypted TCP transport over the Mplex protocol.
-pub fn build_transport(keypair: identity::Keypair) -> io::Result<TTransport> {
-    let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
-        .into_authentic(&keypair)
-        .unwrap();
-    let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
+pub struct TransportBuilder<T: Transport> {
+    keypair: identity::Keypair,
+    transport: T,
+}
 
-    Ok(TokioDnsConfig::system(TokioTcpConfig::new())?
-        .upgrade(Version::V1)
-        .authenticate(noise_config)
-        .multiplex(SelectUpgrade::new(
-            YamuxConfig::default(),
-            MplexConfig::new(),
-        ))
-        .timeout(Duration::from_secs(20))
-        .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-        .map_err(|err| Error::new(ErrorKind::Other, err))
-        .boxed())
+impl
+    TransportBuilder<
+        GenDnsConfig<GenTcpConfig<Tcp>, GenericConnection, GenericConnectionProvider<TokioRuntime>>,
+    >
+{
+    pub fn new(keypair: identity::Keypair) -> io::Result<Self> {
+        Ok(Self {
+            keypair,
+            transport: TokioDnsConfig::system(TokioTcpConfig::new())?,
+        })
+    }
+}
+
+impl<T: Transport> TransportBuilder<T>
+where
+    <T as Transport>::Error: 'static,
+{
+    pub fn or<O: Transport>(self, other: O) -> TransportBuilder<OrTransport<O, T>> {
+        TransportBuilder {
+            keypair: self.keypair,
+            transport: other.or_transport(self.transport),
+        }
+    }
+}
+
+impl<T: Transport + Clone> TransportBuilder<T> {
+    pub fn relay(self) -> (TransportBuilder<RelayTransport<T>>, Relay) {
+        let (transport, relay) =
+            libp2p::relay::new_transport_and_behaviour(Default::default(), self.transport);
+        (
+            TransportBuilder {
+                keypair: self.keypair,
+                transport,
+            },
+            relay,
+        )
+    }
+}
+
+impl<T: Transport + Clone + Send + Sync + 'static> TransportBuilder<T>
+where
+    <T as Transport>::Error: Send + Sync + 'static,
+    <T as Transport>::Output: AsyncWrite + AsyncRead + Unpin + Send + 'static,
+    <T as Transport>::Listener: Send,
+    <T as Transport>::ListenerUpgrade: Send,
+    <T as Transport>::Dial: Send,
+{
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
+    pub fn build_transport(self) -> TTransport {
+        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
+            .into_authentic(&self.keypair)
+            .unwrap();
+        let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
+        self.transport
+            .upgrade(Version::V1)
+            .authenticate(noise_config)
+            .multiplex(SelectUpgrade::new(
+                YamuxConfig::default(),
+                MplexConfig::new(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+            .map_err(|err| Error::new(ErrorKind::Other, err))
+            .boxed()
+    }
+
+    /// Builds the transport that serves as a common ground for all connections.
+    ///
+    /// Set up an encrypted TCP transport over the Mplex protocol.
+    pub fn build_transport_with_upgrade<U, D, E, F, I, It>(self, upgrade: U) -> TTransport
+    where
+        D: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        E: StdError + Send + Sync + 'static,
+        F: Future + Send + Sync,
+        I: IntoIterator<IntoIter = It>,
+        It: Send + Sync + Iterator,
+        <It as Iterator>::Item: Send + Sync,
+        U: Send + Sync + Clone + 'static,
+        U: InboundUpgrade<
+            Negotiated<NoiseOutput<Negotiated<<T as Transport>::Output>>>,
+            Output = D,
+            Error = E,
+            Future = F,
+        >,
+        U: OutboundUpgrade<
+            Negotiated<NoiseOutput<Negotiated<<T as Transport>::Output>>>,
+            Output = D,
+            Error = E,
+            Future = F,
+        >,
+        U: UpgradeInfo<InfoIter = I>,
+        <U as UpgradeInfo>::Info: Send,
+    {
+        let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
+            .into_authentic(&self.keypair)
+            .unwrap();
+        let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
+        self.transport
+            .upgrade(Version::V1)
+            .authenticate(noise_config)
+            .apply(upgrade)
+            .multiplex(SelectUpgrade::new(
+                YamuxConfig::default(),
+                MplexConfig::new(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+            .map_err(|err| Error::new(ErrorKind::Other, err))
+            .boxed()
+    }
+}
+
+pub mod apply_upgrades {
+    use super::{
+        noise, Builder, NoiseAuthenticated, NoiseConfig, TransportBuilder, X25519Spec, XX,
+    };
+
+    pub use std::{
+        io::{Error, ErrorKind},
+        time::Duration,
+    };
+
+    pub use libp2p::{
+        core::{
+            muxing::StreamMuxerBox,
+            upgrade::{SelectUpgrade, Version},
+        },
+        mplex::MplexConfig,
+        yamux::YamuxConfig,
+        Transport,
+    };
+
+    impl<T: Transport> TransportBuilder<T>
+    where
+        <T as Transport>::Error: 'static,
+    {
+        pub fn then(self) -> TransportUpgrader<T> {
+            let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
+                .into_authentic(&self.keypair)
+                .unwrap();
+            let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
+            TransportUpgrader {
+                noise_config,
+                builder: self.transport.upgrade(Version::V1),
+            }
+        }
+    }
+
+    pub struct TransportUpgrader<T: Transport> {
+        pub noise_config: NoiseAuthenticated<XX, X25519Spec, ()>,
+        pub builder: Builder<T>,
+    }
+
+    #[macro_export]
+    macro_rules! apply_upgrades {
+        ($upgrader:expr => $($upgrades:expr),*) => {
+            {
+                use $crate::p2p::transport::apply_upgrades::*;
+                $upgrader.builder
+                    .authenticate($upgrader.noise_config)
+                    $(
+                        .apply($upgrades)
+                    )*
+                    .multiplex(SelectUpgrade::new(
+                        YamuxConfig::default(),
+                        MplexConfig::new(),
+                    ))
+                    .timeout(Duration::from_secs(20))
+                    .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+                    .map_err(|err| Error::new(ErrorKind::Other, err))
+                    .boxed()
+            }
+        };
+    }
 }


### PR DESCRIPTION
* Pull in the network and transport changes to the kepler-staging branch. 
* Revert the "swarm event handler" commit.
* Remove the hard-coding of relay and memory transports, as they can now be included when constructing Ipfs.

Could add more more docstrings, but will leave that for when I get around to PRing this upstream.